### PR TITLE
Better dependencies compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 
 /test/*-test/**/*.bats
 /test/*-test/**/*.actual
+
+/.idea

--- a/src/main/scala/org/deepdive/ddlog/DeepDiveLogCompiler.scala
+++ b/src/main/scala/org/deepdive/ddlog/DeepDiveLogCompiler.scala
@@ -254,6 +254,8 @@ class CompilationState( statements : DeepDiveLog.Program, config : DeepDiveLog.C
         f -> collectUsedRelations(f.q.bodies) }
       case e : ExtractionRule   => dependencies += {
         e -> collectUsedRelations(e.q.bodies) }
+      case e : InferenceRule    => dependencies += {
+        e -> collectUsedRelations(e.q.bodies) }
       case _ =>
     }
   }
@@ -610,6 +612,7 @@ object DeepDiveLogCompiler extends DeepDiveLogHandler {
         sql: \"\"\" ${sqlCmdForCleanUp}
         ${sqlCmdForInsert} ${stmts(0).headName}${useAS} ${inputQueries.mkString("\nUNION ALL\n")}
         \"\"\"
+          output_relation: \"${stmts(0).headName}\"
         style: "sql_extractor"
           ${ss.generateDependenciesOfCompiledBlockFor(stmts)}
       }
@@ -740,6 +743,7 @@ object DeepDiveLogCompiler extends DeepDiveLogHandler {
           input_query: \"\"\"${inputQueries.mkString(" UNION ALL ")}\"\"\"
           function: "${func}"
           weight: "${weight}"
+          ${ss.generateDependenciesOfCompiledBlockFor(stmts)}
         }
       """
     }

--- a/test/expected-output-test/chunking_example/compile.expected
+++ b/test/expected-output-test/chunking_example/compile.expected
@@ -17,58 +17,6 @@
       }
     
 
-          deepdive.extraction.extractors.init_words_raw {
-            sql: """ DROP TABLE IF EXISTS words_raw CASCADE;
-            CREATE TABLE
-            words_raw(word_id bigserial,
-         word text,
-         pos text,
-         tag text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_words {
-            sql: """ DROP TABLE IF EXISTS words CASCADE;
-            CREATE TABLE
-            words(sent_id bigint,
-     word_id bigint,
-     word text,
-     pos text,
-     true_tag int)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_tag {
-            sql: """ DROP TABLE IF EXISTS tag CASCADE;
-            CREATE TABLE
-            tag(word_id bigint,
-   id bigint,
-   label int)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_word_features {
-            sql: """ DROP TABLE IF EXISTS word_features CASCADE;
-            CREATE TABLE
-            word_features(word_id bigint,
-             feature text)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE words_raw;
-          TRUNCATE words;
-          TRUNCATE tag;
-          TRUNCATE word_features;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_tag {
         sql: """ 
         INSERT INTO tag SELECT DISTINCT R0.sent_id, 0 AS id, R0.true_tag AS label
@@ -76,8 +24,12 @@
         
           
         """
+          output_relation: "tag"
         style: "sql_extractor"
           dependencies: [ "ext_words_by_ext_training" ]
+          input_relations: [
+            words
+          ]
       }
     
 
@@ -89,8 +41,11 @@ FROM words_raw R0
           output_relation: "words"
           udf: ${APP_HOME}"/udf/ext_training.py"
           style: "tsv_extractor" 
-         
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          
+          input_relations: [
+            words_raw
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -104,7 +59,10 @@ FROM words R0, words R1
           udf: ${APP_HOME}"/udf/ext_features.py"
           style: "tsv_extractor" 
           dependencies: [ "ext_words_by_ext_training" ]
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            words
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -116,15 +74,14 @@ FROM words R0, words R1
         WHERE R1.word_id = R0.word_id """
           function: "Multinomial(tag.R0.label)"
           weight: "?(dd_weight_column_0)"
+          dependencies: [ "ext_word_features_by_ext_features" ]
+          input_relations: [
+            tag
+            word_features
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_words_raw
-  init_words
-  init_tag
-  init_word_features
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_tag
   ext_words_by_ext_training
@@ -138,7 +95,4 @@ deepdive.pipeline.pipelines.endtoend: [
   ext_words_by_ext_training
   ext_word_features_by_ext_features
   inf_istrue_tag
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]

--- a/test/expected-output-test/expressions/compile.expected
+++ b/test/expected-output-test/expressions/compile.expected
@@ -17,52 +17,18 @@
       }
     
 
-          deepdive.extraction.extractors.init_b {
-            sql: """ DROP TABLE IF EXISTS b CASCADE;
-            CREATE TABLE
-            b(k int,
- p text,
- q text,
- r int)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_a {
-            sql: """ DROP TABLE IF EXISTS a CASCADE;
-            CREATE TABLE
-            a(k int)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_c {
-            sql: """ DROP TABLE IF EXISTS c CASCADE;
-            CREATE TABLE
-            c(s text,
- n int,
- t text)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE b;
-          TRUNCATE a;
-          TRUNCATE c;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_E {
         sql: """ DROP VIEW IF EXISTS E;
         CREATE VIEW E AS SELECT (R0.k :: INT) AS column_0
 FROM b R0
         
         """
+          output_relation: "E"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+          ]
       }
     
 
@@ -72,8 +38,13 @@ FROM b R0
 FROM b R0, c R1
         WHERE R1.n = R0.k 
         """
+          output_relation: "X"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+            c
+          ]
       }
     
 
@@ -83,8 +54,13 @@ FROM b R0, c R1
 FROM b R0
         WHERE EXISTS (SELECT 1 FROM c R1_0 WHERE R1_0.n = R0.k  AND R1_0.s > 'a')
         """
+          output_relation: "N"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+            c
+          ]
       }
     
 
@@ -94,8 +70,13 @@ FROM b R0
 FROM b R0 LEFT OUTER JOIN c R1_0 ON R1_0.n = R0.k  AND R1_0.s > R0.p
         WHERE R1_0.s > R0.p
         """
+          output_relation: "T"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+            c
+          ]
       }
     
 
@@ -105,8 +86,12 @@ FROM b R0 LEFT OUTER JOIN c R1_0 ON R1_0.n = R0.k  AND R1_0.s > R0.p
 FROM b R0
         WHERE ((R0.k + R0.r) = 100 OR (NOT R0.k > 50))
         """
+          output_relation: "J"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+          ]
       }
     
 
@@ -116,8 +101,13 @@ FROM b R0
 FROM b R0_0 ON  FULL OUTER JOIN c R1_0 ON R1_0.n = R0_0.k 
         
         """
+          output_relation: "U"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+            c
+          ]
       }
     
 
@@ -127,8 +117,12 @@ FROM b R0_0 ON  FULL OUTER JOIN c R1_0 ON R1_0.n = R0_0.k
 FROM b R0
         
         """
+          output_relation: "F"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+          ]
       }
     
 
@@ -138,8 +132,12 @@ FROM b R0
 FROM b R0
         
         """
+          output_relation: "A"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+          ]
       }
     
 
@@ -149,8 +147,13 @@ FROM b R0
 FROM b R0
         WHERE EXISTS (SELECT 1 FROM c R1_0 WHERE R1_0.n = R0.k )
         """
+          output_relation: "M"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+            c
+          ]
       }
     
 
@@ -160,8 +163,12 @@ FROM b R0
 FROM b R0
         WHERE ((R0.k + R0.r) = 100 OR (R0.k > 50 AND R0.r < 10))
         """
+          output_relation: "I"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+          ]
       }
     
 
@@ -171,8 +178,12 @@ FROM b R0
 FROM b R0
         WHERE (R0.k + R0.r) = 100
         """
+          output_relation: "G"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+          ]
       }
     
 
@@ -182,8 +193,13 @@ FROM b R0
 FROM c R0, a R1
         WHERE R1.k = R0.n 
         """
+          output_relation: "V"
         style: "sql_extractor"
           
+          input_relations: [
+            c
+            a
+          ]
       }
     
 
@@ -193,8 +209,14 @@ FROM c R0, a R1
 FROM a R0, b R1, c R2
         WHERE R1.k = R0.k  AND R2.s = (R1.p || R1.q) AND R2.n = 10 AND R2.t = 'foo' AND (R1.r > 100 OR ((NOT R1.r < 20) AND R1.r < 50))
         """
+          output_relation: "Q"
         style: "sql_extractor"
           
+          input_relations: [
+            a
+            b
+            c
+          ]
       }
     
 
@@ -204,8 +226,12 @@ FROM a R0, b R1, c R2
 FROM b R0
         LIMIT 100
         """
+          output_relation: "L"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+          ]
       }
     
 
@@ -215,8 +241,12 @@ FROM b R0
 FROM b R0
         
         """
+          output_relation: "B"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+          ]
       }
     
 
@@ -227,8 +257,13 @@ FROM a R0, b R1
         WHERE R1.k = R0.k 
         GROUP BY R1.p, R1.q
         """
+          output_relation: "P"
         style: "sql_extractor"
           
+          input_relations: [
+            a
+            b
+          ]
       }
     
 
@@ -238,8 +273,12 @@ FROM a R0, b R1
 FROM b R0
         
         """
+          output_relation: "C"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+          ]
       }
     
 
@@ -249,8 +288,12 @@ FROM b R0
 FROM b R0
         WHERE ((R0.k + R0.r) = 100 AND R0.k > 50)
         """
+          output_relation: "H"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+          ]
       }
     
 
@@ -260,8 +303,13 @@ FROM b R0
 FROM a R0
         WHERE NOT EXISTS (SELECT 1 FROM c R1_0 WHERE NOT (R1_0.n < R0.k))
         """
+          output_relation: "W"
         style: "sql_extractor"
           
+          input_relations: [
+            a
+            c
+          ]
       }
     
 
@@ -271,8 +319,12 @@ FROM a R0
 FROM b R0
         WHERE ((R0.k + R0.r) = 100 AND ((NOT R0.k > 50) OR R0.k = 40))
         """
+          output_relation: "K"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+          ]
       }
     
 
@@ -282,8 +334,14 @@ FROM b R0
 FROM b R0
         WHERE EXISTS (SELECT 1 FROM c R1_0, a R1_1 WHERE R1_0.n = R0.k  AND R1_1.k = R0.k )
         """
+          output_relation: "O"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+            c
+            a
+          ]
       }
     
 
@@ -293,8 +351,12 @@ FROM b R0
 FROM b R0
         
         """
+          output_relation: "D"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+          ]
       }
     
 
@@ -304,16 +366,16 @@ FROM b R0
 FROM b R0 LEFT OUTER JOIN c R1_0 ON R1_0.n = R0.k 
         
         """
+          output_relation: "S"
         style: "sql_extractor"
           
+          input_relations: [
+            b
+            c
+          ]
       }
     
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_b
-  init_a
-  init_c
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_M
   ext_Q
@@ -363,7 +425,4 @@ deepdive.pipeline.pipelines.endtoend: [
   ext_C
   ext_V
   ext_H
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]

--- a/test/expected-output-test/multiple_rules_for_same_head/compile-incremental.expected
+++ b/test/expected-output-test/multiple_rules_for_same_head/compile-incremental.expected
@@ -23,79 +23,6 @@ dd_new_Q.label: Boolean
       }
     
 
-          deepdive.extraction.extractors.init_dd_new_S {
-            sql: """ DROP TABLE IF EXISTS dd_new_S CASCADE;
-            CREATE TABLE
-            dd_new_S(a int)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_T {
-            sql: """ DROP TABLE IF EXISTS dd_delta_T CASCADE;
-            CREATE TABLE
-            dd_delta_T(a int)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_T {
-            sql: """ DROP TABLE IF EXISTS dd_new_T CASCADE;
-            CREATE TABLE
-            dd_new_T(a int)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_S {
-            sql: """ DROP TABLE IF EXISTS dd_delta_S CASCADE;
-            CREATE TABLE
-            dd_delta_S(a int)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_R {
-            sql: """ DROP TABLE IF EXISTS dd_new_R CASCADE;
-            CREATE TABLE
-            dd_new_R(a int,
-        b int)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_R {
-            sql: """ DROP TABLE IF EXISTS dd_delta_R CASCADE;
-            CREATE TABLE
-            dd_delta_R(a int,
-          b int)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_Q {
-            sql: """ DROP TABLE IF EXISTS dd_delta_Q CASCADE;
-            CREATE TABLE
-            dd_delta_Q(x int,
-          id bigint,
-          label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE dd_new_S;
-          TRUNCATE dd_delta_T;
-          TRUNCATE dd_new_T;
-          TRUNCATE dd_delta_S;
-          TRUNCATE dd_new_R;
-          TRUNCATE dd_delta_R;
-          TRUNCATE dd_delta_Q;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_dd_new_S {
         sql: """ TRUNCATE dd_new_S;
         INSERT INTO dd_new_S SELECT R0.a
@@ -106,8 +33,13 @@ SELECT R0.a
 FROM dd_delta_S R0
         
         """
+          output_relation: "dd_new_S"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_S" ,  "ext1_dd_delta_S_by_f" ,  "ext_dd_delta_S_by_f" ,  "ext_dd_delta_S_by_f_1" ]
+          input_relations: [
+            S
+            dd_delta_S
+          ]
       }
     
 
@@ -121,8 +53,13 @@ SELECT R0.a
 FROM dd_delta_T R0
         
         """
+          output_relation: "dd_new_T"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_T_by_f" ,  "ext1_dd_delta_T_by_f" ,  "ext2_dd_delta_T_by_f" ,  "ext_dd_delta_T_by_f_1" ]
+          input_relations: [
+            T
+            dd_delta_T
+          ]
       }
     
 
@@ -152,8 +89,14 @@ SELECT R0.a AS "dd_new_R.R0.a"
 FROM dd_new_R R0, dd_delta_R R1
         WHERE R1.a = R0.b  AND R0.a = 0
         """
+          output_relation: "dd_delta_S"
         style: "sql_extractor"
           dependencies: [ "ext_dd_new_R" ]
+          input_relations: [
+            dd_delta_R
+            R
+            dd_new_R
+          ]
       }
     
 
@@ -167,8 +110,13 @@ SELECT R0.a, R0.b
 FROM dd_delta_R R0
         
         """
+          output_relation: "dd_new_R"
         style: "sql_extractor"
           
+          input_relations: [
+            R
+            dd_delta_R
+          ]
       }
     
 
@@ -184,8 +132,13 @@ SELECT DISTINCT R0.x, id, label
         
           
         """
+          output_relation: "dd_new_Q"
         style: "sql_extractor"
           
+          input_relations: [
+            Q
+            dd_delta_Q
+          ]
       }
     
 
@@ -198,7 +151,10 @@ FROM dd_delta_R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            dd_delta_R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -212,7 +168,10 @@ FROM dd_delta_R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            dd_delta_R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -226,7 +185,10 @@ FROM dd_delta_R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            dd_delta_R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -240,7 +202,10 @@ FROM dd_delta_R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            dd_delta_R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -254,7 +219,10 @@ FROM dd_delta_R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            dd_delta_R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -268,7 +236,10 @@ FROM dd_delta_R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            dd_delta_R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -282,7 +253,10 @@ FROM dd_delta_R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            dd_delta_R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -294,6 +268,11 @@ FROM dd_delta_R R0
         WHERE R1.a = R0.x  AND R0.x > 1000"""
           function: "Imply(dd_new_Q.R0.label)"
           weight: "?(dd_weight_column_0)"
+          dependencies: [ "ext_dd_delta_S" ,  "ext1_dd_delta_S_by_f" ,  "ext_dd_delta_S_by_f" ,  "ext_dd_delta_S_by_f_1" ]
+          input_relations: [
+            dd_new_Q
+            dd_delta_S
+          ]
         }
       
 
@@ -304,6 +283,11 @@ FROM dd_delta_R R0
         WHERE R1.a = R0.x  AND R0.x = 0"""
           function: "Imply(dd_new_Q.R0.label)"
           weight: "1.0"
+          dependencies: [ "ext_dd_delta_S" ,  "ext1_dd_delta_S_by_f" ,  "ext_dd_delta_S_by_f" ,  "ext_dd_delta_S_by_f_1" ]
+          input_relations: [
+            dd_new_Q
+            dd_delta_S
+          ]
         }
       
 
@@ -320,6 +304,16 @@ FROM dd_delta_R R0
         WHERE R2.a = R0.x  AND R3.a = R0.x  AND R3.b = R1.x  AND R4.a = R1.x """
           function: "Imply(dd_new_Q.R0.label, dd_new_Q.R1.label)"
           weight: "?(dd_weight_column_0)"
+          dependencies: [ "ext_dd_new_R" ,  "ext_dd_delta_S_by_f" ,  "ext1_dd_delta_S_by_f" ,  "ext_dd_new_S" ,  "ext_dd_delta_S_by_f_1" ,  "ext_dd_delta_S" ]
+          input_relations: [
+            dd_new_Q
+            dd_delta_S
+            R
+            S
+            dd_new_S
+            dd_delta_R
+            dd_new_R
+          ]
         }
       
 
@@ -336,19 +330,19 @@ FROM dd_delta_R R0
         WHERE R2.a = R0.x  AND R3.a = R0.x  AND R3.b = R1.x  AND R4.a = R1.x  AND (R0.x + R1.x) < 1000"""
           function: "Imply(dd_new_Q.R0.label, dd_new_Q.R1.label)"
           weight: "-10.0"
+          dependencies: [ "ext_dd_new_R" ,  "ext_dd_delta_S_by_f" ,  "ext1_dd_delta_S_by_f" ,  "ext_dd_new_S" ,  "ext_dd_delta_S_by_f_1" ,  "ext_dd_delta_S" ]
+          input_relations: [
+            dd_new_Q
+            dd_delta_S
+            R
+            S
+            dd_new_S
+            dd_delta_R
+            dd_new_R
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_dd_new_S
-  init_dd_delta_T
-  init_dd_new_T
-  init_dd_delta_S
-  init_dd_new_R
-  init_dd_delta_R
-  init_dd_new_Q
-  init_dd_delta_Q
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_dd_new_R
   ext_dd_delta_T_by_f
@@ -386,8 +380,5 @@ deepdive.pipeline.pipelines.endtoend: [
   dd_delta_inf1_istrue_Q
   dd_delta_inf_imply_Q_Q
   dd_delta_inf1_imply_Q_Q
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]
 deepdive.pipeline.base_dir: ${BASEDIR}

--- a/test/expected-output-test/multiple_rules_for_same_head/compile-incremental.expected
+++ b/test/expected-output-test/multiple_rules_for_same_head/compile-incremental.expected
@@ -23,6 +23,79 @@ dd_new_Q.label: Boolean
       }
     
 
+          deepdive.extraction.extractors.init_dd_new_S {
+            sql: """ DROP TABLE IF EXISTS dd_new_S CASCADE;
+            CREATE TABLE
+            dd_new_S(a int)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_T {
+            sql: """ DROP TABLE IF EXISTS dd_delta_T CASCADE;
+            CREATE TABLE
+            dd_delta_T(a int)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_T {
+            sql: """ DROP TABLE IF EXISTS dd_new_T CASCADE;
+            CREATE TABLE
+            dd_new_T(a int)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_S {
+            sql: """ DROP TABLE IF EXISTS dd_delta_S CASCADE;
+            CREATE TABLE
+            dd_delta_S(a int)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_R {
+            sql: """ DROP TABLE IF EXISTS dd_new_R CASCADE;
+            CREATE TABLE
+            dd_new_R(a int,
+        b int)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_R {
+            sql: """ DROP TABLE IF EXISTS dd_delta_R CASCADE;
+            CREATE TABLE
+            dd_delta_R(a int,
+          b int)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_Q {
+            sql: """ DROP TABLE IF EXISTS dd_delta_Q CASCADE;
+            CREATE TABLE
+            dd_delta_Q(x int,
+          id bigint,
+          label boolean)
+            """
+            style: "sql_extractor"
+          }
+
+        deepdive.extraction.extractors.cleanup {
+          sql: """
+          TRUNCATE dd_new_S;
+          TRUNCATE dd_delta_T;
+          TRUNCATE dd_new_T;
+          TRUNCATE dd_delta_S;
+          TRUNCATE dd_new_R;
+          TRUNCATE dd_delta_R;
+          TRUNCATE dd_delta_Q;
+          """
+          style: "sql_extractor"
+        }
+
       deepdive.extraction.extractors.ext_dd_new_S {
         sql: """ TRUNCATE dd_new_S;
         INSERT INTO dd_new_S SELECT R0.a
@@ -382,3 +455,16 @@ deepdive.pipeline.pipelines.endtoend: [
   dd_delta_inf1_imply_Q_Q
 ]
 deepdive.pipeline.base_dir: ${BASEDIR}
+deepdive.pipeline.pipelines.initdb: [
+  init_dd_new_S
+  init_dd_delta_T
+  init_dd_new_T
+  init_dd_delta_S
+  init_dd_new_R
+  init_dd_delta_R
+  init_dd_new_Q
+  init_dd_delta_Q
+]
+deepdive.pipeline.pipelines.cleanup: [
+  cleanup
+]

--- a/test/expected-output-test/multiple_rules_for_same_head/compile.expected
+++ b/test/expected-output-test/multiple_rules_for_same_head/compile.expected
@@ -17,51 +17,6 @@
       }
     
 
-          deepdive.extraction.extractors.init_S {
-            sql: """ DROP TABLE IF EXISTS S CASCADE;
-            CREATE TABLE
-            S(a int)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_R {
-            sql: """ DROP TABLE IF EXISTS R CASCADE;
-            CREATE TABLE
-            R(a int,
- b int)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_Q {
-            sql: """ DROP TABLE IF EXISTS Q CASCADE;
-            CREATE TABLE
-            Q(x int,
- id bigint,
- label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_T {
-            sql: """ DROP TABLE IF EXISTS T CASCADE;
-            CREATE TABLE
-            T(a int)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE S;
-          TRUNCATE R;
-          TRUNCATE Q;
-          TRUNCATE T;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_S {
         sql: """ 
         INSERT INTO S SELECT R0.a AS "R.R0.a"
@@ -76,8 +31,12 @@ SELECT R0.a AS "R.R0.a"
 FROM R R0, R R1
         WHERE R1.a = R0.b  AND R0.a = 0
         """
+          output_relation: "S"
         style: "sql_extractor"
           
+          input_relations: [
+            R
+          ]
       }
     
 
@@ -90,7 +49,10 @@ FROM R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -104,7 +66,10 @@ FROM R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -118,7 +83,10 @@ FROM R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -132,7 +100,10 @@ FROM R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -146,7 +117,10 @@ FROM R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -160,7 +134,10 @@ FROM R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -174,7 +151,10 @@ FROM R R0
           udf: ${APP_HOME}"//bin/false"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            R
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -186,6 +166,11 @@ FROM R R0
         WHERE R1.a = R0.x  AND R0.x > 1000"""
           function: "Imply(Q.R0.label)"
           weight: "?(dd_weight_column_0)"
+          dependencies: [ "ext1_S_by_f" ,  "ext_S" ,  "ext_S_by_f_1" ,  "ext_S_by_f" ]
+          input_relations: [
+            Q
+            S
+          ]
         }
       
 
@@ -196,6 +181,11 @@ FROM R R0
         WHERE R1.a = R0.x  AND R0.x = 0"""
           function: "Imply(Q.R0.label)"
           weight: "1.0"
+          dependencies: [ "ext1_S_by_f" ,  "ext_S" ,  "ext_S_by_f_1" ,  "ext_S_by_f" ]
+          input_relations: [
+            Q
+            S
+          ]
         }
       
 
@@ -206,6 +196,12 @@ FROM R R0
         WHERE R2.a = R0.x  AND R3.a = R0.x  AND R3.b = R1.x  AND R4.a = R1.x """
           function: "Imply(Q.R0.label, Q.R1.label)"
           weight: "?(dd_weight_column_0)"
+          dependencies: [ "ext1_S_by_f" ,  "ext_S" ,  "ext_S_by_f_1" ,  "ext_S_by_f" ]
+          input_relations: [
+            Q
+            S
+            R
+          ]
         }
       
 
@@ -216,15 +212,15 @@ FROM R R0
         WHERE R2.a = R0.x  AND R3.a = R0.x  AND R3.b = R1.x  AND R4.a = R1.x  AND (R0.x + R1.x) < 1000"""
           function: "Imply(Q.R0.label, Q.R1.label)"
           weight: "-10.0"
+          dependencies: [ "ext1_S_by_f" ,  "ext_S" ,  "ext_S_by_f_1" ,  "ext_S_by_f" ]
+          input_relations: [
+            Q
+            S
+            R
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_S
-  init_R
-  init_Q
-  init_T
-]
 deepdive.pipeline.pipelines.extraction: [
   ext2_T_by_f
   ext_S_by_f_1
@@ -254,7 +250,4 @@ deepdive.pipeline.pipelines.endtoend: [
   inf1_istrue_Q
   inf_imply_Q_Q
   inf1_imply_Q_Q
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]

--- a/test/expected-output-test/ocr_example/compile-incremental.expected
+++ b/test/expected-output-test/ocr_example/compile-incremental.expected
@@ -28,6 +28,98 @@ q1.label: Boolean
       }
     
 
+          deepdive.extraction.extractors.init_dd_new_label2 {
+            sql: """ DROP TABLE IF EXISTS dd_new_label2 CASCADE;
+            CREATE TABLE
+            dd_new_label2(wid INT,
+             val BOOLEAN)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_label1 {
+            sql: """ DROP TABLE IF EXISTS dd_delta_label1 CASCADE;
+            CREATE TABLE
+            dd_delta_label1(wid INT,
+               val BOOLEAN)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_label1 {
+            sql: """ DROP TABLE IF EXISTS dd_new_label1 CASCADE;
+            CREATE TABLE
+            dd_new_label1(wid INT,
+             val BOOLEAN)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_features {
+            sql: """ DROP TABLE IF EXISTS dd_delta_features CASCADE;
+            CREATE TABLE
+            dd_delta_features(id BIGSERIAL,
+                 word_id INT,
+                 feature_id INT,
+                 feature_val BOOLEAN)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_q2 {
+            sql: """ DROP TABLE IF EXISTS dd_delta_q2 CASCADE;
+            CREATE TABLE
+            dd_delta_q2(wid INT,
+           id bigint,
+           label boolean)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_label2 {
+            sql: """ DROP TABLE IF EXISTS dd_delta_label2 CASCADE;
+            CREATE TABLE
+            dd_delta_label2(wid INT,
+               val BOOLEAN)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_features {
+            sql: """ DROP TABLE IF EXISTS dd_new_features CASCADE;
+            CREATE TABLE
+            dd_new_features(id BIGSERIAL,
+               word_id INT,
+               feature_id INT,
+               feature_val BOOLEAN)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_q1 {
+            sql: """ DROP TABLE IF EXISTS dd_delta_q1 CASCADE;
+            CREATE TABLE
+            dd_delta_q1(wid INT,
+           id bigint,
+           label boolean)
+            """
+            style: "sql_extractor"
+          }
+
+        deepdive.extraction.extractors.cleanup {
+          sql: """
+          TRUNCATE dd_new_label2;
+          TRUNCATE dd_delta_label1;
+          TRUNCATE dd_new_label1;
+          TRUNCATE dd_delta_features;
+          TRUNCATE dd_delta_q2;
+          TRUNCATE dd_delta_label2;
+          TRUNCATE dd_new_features;
+          TRUNCATE dd_delta_q1;
+          """
+          style: "sql_extractor"
+        }
+
       deepdive.extraction.extractors.ext_dd_new_label2 {
         sql: """ TRUNCATE dd_new_label2;
         INSERT INTO dd_new_label2 SELECT R0.wid, R0.val
@@ -219,3 +311,18 @@ deepdive.pipeline.pipelines.endtoend: [
   dd_delta_inf_istrue_q2
 ]
 deepdive.pipeline.base_dir: ${BASEDIR}
+deepdive.pipeline.pipelines.initdb: [
+  init_dd_new_label2
+  init_dd_delta_label1
+  init_dd_new_q1
+  init_dd_new_label1
+  init_dd_delta_features
+  init_dd_delta_q2
+  init_dd_delta_label2
+  init_dd_new_features
+  init_dd_delta_q1
+  init_dd_new_q2
+]
+deepdive.pipeline.pipelines.cleanup: [
+  cleanup
+]

--- a/test/expected-output-test/ocr_example/compile-incremental.expected
+++ b/test/expected-output-test/ocr_example/compile-incremental.expected
@@ -28,98 +28,6 @@ q1.label: Boolean
       }
     
 
-          deepdive.extraction.extractors.init_dd_new_label2 {
-            sql: """ DROP TABLE IF EXISTS dd_new_label2 CASCADE;
-            CREATE TABLE
-            dd_new_label2(wid INT,
-             val BOOLEAN)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_label1 {
-            sql: """ DROP TABLE IF EXISTS dd_delta_label1 CASCADE;
-            CREATE TABLE
-            dd_delta_label1(wid INT,
-               val BOOLEAN)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_label1 {
-            sql: """ DROP TABLE IF EXISTS dd_new_label1 CASCADE;
-            CREATE TABLE
-            dd_new_label1(wid INT,
-             val BOOLEAN)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_features {
-            sql: """ DROP TABLE IF EXISTS dd_delta_features CASCADE;
-            CREATE TABLE
-            dd_delta_features(id BIGSERIAL,
-                 word_id INT,
-                 feature_id INT,
-                 feature_val BOOLEAN)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_q2 {
-            sql: """ DROP TABLE IF EXISTS dd_delta_q2 CASCADE;
-            CREATE TABLE
-            dd_delta_q2(wid INT,
-           id bigint,
-           label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_label2 {
-            sql: """ DROP TABLE IF EXISTS dd_delta_label2 CASCADE;
-            CREATE TABLE
-            dd_delta_label2(wid INT,
-               val BOOLEAN)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_features {
-            sql: """ DROP TABLE IF EXISTS dd_new_features CASCADE;
-            CREATE TABLE
-            dd_new_features(id BIGSERIAL,
-               word_id INT,
-               feature_id INT,
-               feature_val BOOLEAN)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_q1 {
-            sql: """ DROP TABLE IF EXISTS dd_delta_q1 CASCADE;
-            CREATE TABLE
-            dd_delta_q1(wid INT,
-           id bigint,
-           label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE dd_new_label2;
-          TRUNCATE dd_delta_label1;
-          TRUNCATE dd_new_label1;
-          TRUNCATE dd_delta_features;
-          TRUNCATE dd_delta_q2;
-          TRUNCATE dd_delta_label2;
-          TRUNCATE dd_new_features;
-          TRUNCATE dd_delta_q1;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_dd_new_label2 {
         sql: """ TRUNCATE dd_new_label2;
         INSERT INTO dd_new_label2 SELECT R0.wid, R0.val
@@ -130,8 +38,13 @@ SELECT R0.wid, R0.val
 FROM dd_delta_label2 R0
         
         """
+          output_relation: "dd_new_label2"
         style: "sql_extractor"
           
+          input_relations: [
+            label2
+            dd_delta_label2
+          ]
       }
     
 
@@ -147,8 +60,13 @@ SELECT DISTINCT R0.wid, id, label
         
           
         """
+          output_relation: "dd_new_q1"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_q1" ]
+          input_relations: [
+            q1
+            dd_delta_q1
+          ]
       }
     
 
@@ -162,8 +80,13 @@ SELECT R0.wid, R0.val
 FROM dd_delta_label1 R0
         
         """
+          output_relation: "dd_new_label1"
         style: "sql_extractor"
           
+          input_relations: [
+            label1
+            dd_delta_label1
+          ]
       }
     
 
@@ -174,8 +97,12 @@ FROM dd_delta_label1 R0
         
           
         """
+          output_relation: "dd_delta_q2"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_delta_label2
+          ]
       }
     
 
@@ -189,8 +116,13 @@ SELECT R0.id, R0.word_id, R0.feature_id, R0.feature_val
 FROM dd_delta_features R0
         
         """
+          output_relation: "dd_new_features"
         style: "sql_extractor"
           
+          input_relations: [
+            features
+            dd_delta_features
+          ]
       }
     
 
@@ -201,8 +133,12 @@ FROM dd_delta_features R0
         
           
         """
+          output_relation: "dd_delta_q1"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_delta_label1
+          ]
       }
     
 
@@ -218,8 +154,13 @@ SELECT DISTINCT R0.wid, id, label
         
           
         """
+          output_relation: "dd_new_q2"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_q2" ]
+          input_relations: [
+            q2
+            dd_delta_q2
+          ]
       }
     
 
@@ -230,6 +171,11 @@ SELECT DISTINCT R0.wid, id, label
         WHERE R1.word_id = R0.wid """
           function: "Imply(dd_new_q1.R0.label)"
           weight: "?(dd_weight_column_0)"
+          
+          input_relations: [
+            dd_new_q1
+            dd_delta_features
+          ]
         }
       
 
@@ -240,21 +186,14 @@ SELECT DISTINCT R0.wid, id, label
         WHERE R1.word_id = R0.wid """
           function: "Imply(dd_new_q2.R0.label)"
           weight: "?(dd_weight_column_0)"
+          
+          input_relations: [
+            dd_new_q2
+            dd_delta_features
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_dd_new_label2
-  init_dd_delta_label1
-  init_dd_new_q1
-  init_dd_new_label1
-  init_dd_delta_features
-  init_dd_delta_q2
-  init_dd_delta_label2
-  init_dd_new_features
-  init_dd_delta_q1
-  init_dd_new_q2
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_dd_delta_q1
   ext_dd_new_q1
@@ -278,8 +217,5 @@ deepdive.pipeline.pipelines.endtoend: [
   ext_dd_new_q2
   dd_delta_inf_istrue_q1
   dd_delta_inf_istrue_q2
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]
 deepdive.pipeline.base_dir: ${BASEDIR}

--- a/test/expected-output-test/ocr_example/compile-materialization.expected
+++ b/test/expected-output-test/ocr_example/compile-materialization.expected
@@ -18,66 +18,6 @@ q2.label: Boolean
       }
     
 
-          deepdive.extraction.extractors.init_label1 {
-            sql: """ DROP TABLE IF EXISTS label1 CASCADE;
-            CREATE TABLE
-            label1(wid INT,
-      val BOOLEAN)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_features {
-            sql: """ DROP TABLE IF EXISTS features CASCADE;
-            CREATE TABLE
-            features(id BIGSERIAL,
-        word_id INT,
-        feature_id INT,
-        feature_val BOOLEAN)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_label2 {
-            sql: """ DROP TABLE IF EXISTS label2 CASCADE;
-            CREATE TABLE
-            label2(wid INT,
-      val BOOLEAN)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_q1 {
-            sql: """ DROP TABLE IF EXISTS q1 CASCADE;
-            CREATE TABLE
-            q1(wid INT,
-  id bigint,
-  label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_q2 {
-            sql: """ DROP TABLE IF EXISTS q2 CASCADE;
-            CREATE TABLE
-            q2(wid INT,
-  id bigint,
-  label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE label1;
-          TRUNCATE features;
-          TRUNCATE label2;
-          TRUNCATE q1;
-          TRUNCATE q2;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_q1 {
         sql: """ 
         INSERT INTO q1 SELECT DISTINCT R0.wid, 0 AS id, R0.val AS label
@@ -85,8 +25,12 @@ q2.label: Boolean
         
           
         """
+          output_relation: "q1"
         style: "sql_extractor"
           
+          input_relations: [
+            label1
+          ]
       }
     
 
@@ -97,8 +41,12 @@ q2.label: Boolean
         
           
         """
+          output_relation: "q2"
         style: "sql_extractor"
           
+          input_relations: [
+            label2
+          ]
       }
     
 
@@ -109,6 +57,11 @@ q2.label: Boolean
         WHERE R1.word_id = R0.wid """
           function: "Imply(q1.R0.label)"
           weight: "?(dd_weight_column_0)"
+          
+          input_relations: [
+            q1
+            features
+          ]
         }
       
 
@@ -119,16 +72,14 @@ q2.label: Boolean
         WHERE R1.word_id = R0.wid """
           function: "Imply(q2.R0.label)"
           weight: "?(dd_weight_column_0)"
+          
+          input_relations: [
+            q2
+            features
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_label1
-  init_features
-  init_label2
-  init_q1
-  init_q2
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_q1
   ext_q2

--- a/test/expected-output-test/ocr_example/compile-merge.expected
+++ b/test/expected-output-test/ocr_example/compile-merge.expected
@@ -23,8 +23,12 @@
 FROM dd_new_label2 R0
         
         """
+          output_relation: "label2"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_new_label2
+          ]
       }
     
 
@@ -34,8 +38,12 @@ FROM dd_new_label2 R0
 FROM dd_new_label1 R0
         
         """
+          output_relation: "label1"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_new_label1
+          ]
       }
     
 
@@ -45,8 +53,12 @@ FROM dd_new_label1 R0
 FROM dd_new_features R0
         
         """
+          output_relation: "features"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_new_features
+          ]
       }
     
 deepdive.pipeline.run: ${PIPELINE}

--- a/test/expected-output-test/ocr_example/compile.expected
+++ b/test/expected-output-test/ocr_example/compile.expected
@@ -18,66 +18,6 @@ q2.label: Boolean
       }
     
 
-          deepdive.extraction.extractors.init_label1 {
-            sql: """ DROP TABLE IF EXISTS label1 CASCADE;
-            CREATE TABLE
-            label1(wid INT,
-      val BOOLEAN)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_features {
-            sql: """ DROP TABLE IF EXISTS features CASCADE;
-            CREATE TABLE
-            features(id BIGSERIAL,
-        word_id INT,
-        feature_id INT,
-        feature_val BOOLEAN)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_label2 {
-            sql: """ DROP TABLE IF EXISTS label2 CASCADE;
-            CREATE TABLE
-            label2(wid INT,
-      val BOOLEAN)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_q1 {
-            sql: """ DROP TABLE IF EXISTS q1 CASCADE;
-            CREATE TABLE
-            q1(wid INT,
-  id bigint,
-  label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_q2 {
-            sql: """ DROP TABLE IF EXISTS q2 CASCADE;
-            CREATE TABLE
-            q2(wid INT,
-  id bigint,
-  label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE label1;
-          TRUNCATE features;
-          TRUNCATE label2;
-          TRUNCATE q1;
-          TRUNCATE q2;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_q1 {
         sql: """ 
         INSERT INTO q1 SELECT DISTINCT R0.wid, 0 AS id, R0.val AS label
@@ -85,8 +25,12 @@ q2.label: Boolean
         
           
         """
+          output_relation: "q1"
         style: "sql_extractor"
           
+          input_relations: [
+            label1
+          ]
       }
     
 
@@ -97,8 +41,12 @@ q2.label: Boolean
         
           
         """
+          output_relation: "q2"
         style: "sql_extractor"
           
+          input_relations: [
+            label2
+          ]
       }
     
 
@@ -109,6 +57,11 @@ q2.label: Boolean
         WHERE R1.word_id = R0.wid """
           function: "Imply(q1.R0.label)"
           weight: "?(dd_weight_column_0)"
+          
+          input_relations: [
+            q1
+            features
+          ]
         }
       
 
@@ -119,16 +72,14 @@ q2.label: Boolean
         WHERE R1.word_id = R0.wid """
           function: "Imply(q2.R0.label)"
           weight: "?(dd_weight_column_0)"
+          
+          input_relations: [
+            q2
+            features
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_label1
-  init_features
-  init_label2
-  init_q1
-  init_q2
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_q1
   ext_q2
@@ -142,7 +93,4 @@ deepdive.pipeline.pipelines.endtoend: [
   ext_q2
   inf_istrue_q1
   inf_istrue_q2
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]

--- a/test/expected-output-test/smoke_example/compile-incremental.expected
+++ b/test/expected-output-test/smoke_example/compile-incremental.expected
@@ -28,6 +28,114 @@ dd_delta_smoke.label: Boolean
       }
     
 
+          deepdive.extraction.extractors.init_dd_delta_friends {
+            sql: """ DROP TABLE IF EXISTS dd_delta_friends CASCADE;
+            CREATE TABLE
+            dd_delta_friends(person_id bigint,
+                friend_id bigint)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_smoke {
+            sql: """ DROP TABLE IF EXISTS dd_delta_smoke CASCADE;
+            CREATE TABLE
+            dd_delta_smoke(person_id bigint,
+              id bigint,
+              label boolean)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_person_has_cancer {
+            sql: """ DROP TABLE IF EXISTS dd_new_person_has_cancer CASCADE;
+            CREATE TABLE
+            dd_new_person_has_cancer(person_id bigint,
+                        has_cancer boolean)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_person {
+            sql: """ DROP TABLE IF EXISTS dd_delta_person CASCADE;
+            CREATE TABLE
+            dd_delta_person(person_id bigint,
+               name text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_person {
+            sql: """ DROP TABLE IF EXISTS dd_new_person CASCADE;
+            CREATE TABLE
+            dd_new_person(person_id bigint,
+             name text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_person_has_cancer {
+            sql: """ DROP TABLE IF EXISTS dd_delta_person_has_cancer CASCADE;
+            CREATE TABLE
+            dd_delta_person_has_cancer(person_id bigint,
+                          has_cancer boolean)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_cancer {
+            sql: """ DROP TABLE IF EXISTS dd_delta_cancer CASCADE;
+            CREATE TABLE
+            dd_delta_cancer(person_id bigint,
+               id bigint,
+               label boolean)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_person_smokes {
+            sql: """ DROP TABLE IF EXISTS dd_delta_person_smokes CASCADE;
+            CREATE TABLE
+            dd_delta_person_smokes(person_id bigint,
+                      smokes boolean)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_person_smokes {
+            sql: """ DROP TABLE IF EXISTS dd_new_person_smokes CASCADE;
+            CREATE TABLE
+            dd_new_person_smokes(person_id bigint,
+                    smokes boolean)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_friends {
+            sql: """ DROP TABLE IF EXISTS dd_new_friends CASCADE;
+            CREATE TABLE
+            dd_new_friends(person_id bigint,
+              friend_id bigint)
+            """
+            style: "sql_extractor"
+          }
+
+        deepdive.extraction.extractors.cleanup {
+          sql: """
+          TRUNCATE dd_delta_friends;
+          TRUNCATE dd_delta_smoke;
+          TRUNCATE dd_new_person_has_cancer;
+          TRUNCATE dd_delta_person;
+          TRUNCATE dd_new_person;
+          TRUNCATE dd_delta_person_has_cancer;
+          TRUNCATE dd_delta_cancer;
+          TRUNCATE dd_delta_person_smokes;
+          TRUNCATE dd_new_person_smokes;
+          TRUNCATE dd_new_friends;
+          """
+          style: "sql_extractor"
+        }
+
       deepdive.extraction.extractors.ext_dd_delta_smoke {
         sql: """ 
         INSERT INTO dd_delta_smoke SELECT DISTINCT R0.person_id, 0 AS id, R0.smokes AS label
@@ -242,3 +350,20 @@ deepdive.pipeline.pipelines.endtoend: [
   dd_delta_inf_imply_smoke_smoke
 ]
 deepdive.pipeline.base_dir: ${BASEDIR}
+deepdive.pipeline.pipelines.initdb: [
+  init_dd_delta_friends
+  init_dd_delta_smoke
+  init_dd_new_person_has_cancer
+  init_dd_delta_person
+  init_dd_new_person
+  init_dd_delta_person_has_cancer
+  init_dd_new_smoke
+  init_dd_delta_cancer
+  init_dd_new_cancer
+  init_dd_delta_person_smokes
+  init_dd_new_person_smokes
+  init_dd_new_friends
+]
+deepdive.pipeline.pipelines.cleanup: [
+  cleanup
+]

--- a/test/expected-output-test/smoke_example/compile-incremental.expected
+++ b/test/expected-output-test/smoke_example/compile-incremental.expected
@@ -28,114 +28,6 @@ dd_delta_smoke.label: Boolean
       }
     
 
-          deepdive.extraction.extractors.init_dd_delta_friends {
-            sql: """ DROP TABLE IF EXISTS dd_delta_friends CASCADE;
-            CREATE TABLE
-            dd_delta_friends(person_id bigint,
-                friend_id bigint)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_smoke {
-            sql: """ DROP TABLE IF EXISTS dd_delta_smoke CASCADE;
-            CREATE TABLE
-            dd_delta_smoke(person_id bigint,
-              id bigint,
-              label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_person_has_cancer {
-            sql: """ DROP TABLE IF EXISTS dd_new_person_has_cancer CASCADE;
-            CREATE TABLE
-            dd_new_person_has_cancer(person_id bigint,
-                        has_cancer boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_person {
-            sql: """ DROP TABLE IF EXISTS dd_delta_person CASCADE;
-            CREATE TABLE
-            dd_delta_person(person_id bigint,
-               name text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_person {
-            sql: """ DROP TABLE IF EXISTS dd_new_person CASCADE;
-            CREATE TABLE
-            dd_new_person(person_id bigint,
-             name text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_person_has_cancer {
-            sql: """ DROP TABLE IF EXISTS dd_delta_person_has_cancer CASCADE;
-            CREATE TABLE
-            dd_delta_person_has_cancer(person_id bigint,
-                          has_cancer boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_cancer {
-            sql: """ DROP TABLE IF EXISTS dd_delta_cancer CASCADE;
-            CREATE TABLE
-            dd_delta_cancer(person_id bigint,
-               id bigint,
-               label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_person_smokes {
-            sql: """ DROP TABLE IF EXISTS dd_delta_person_smokes CASCADE;
-            CREATE TABLE
-            dd_delta_person_smokes(person_id bigint,
-                      smokes boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_person_smokes {
-            sql: """ DROP TABLE IF EXISTS dd_new_person_smokes CASCADE;
-            CREATE TABLE
-            dd_new_person_smokes(person_id bigint,
-                    smokes boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_friends {
-            sql: """ DROP TABLE IF EXISTS dd_new_friends CASCADE;
-            CREATE TABLE
-            dd_new_friends(person_id bigint,
-              friend_id bigint)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE dd_delta_friends;
-          TRUNCATE dd_delta_smoke;
-          TRUNCATE dd_new_person_has_cancer;
-          TRUNCATE dd_delta_person;
-          TRUNCATE dd_new_person;
-          TRUNCATE dd_delta_person_has_cancer;
-          TRUNCATE dd_delta_cancer;
-          TRUNCATE dd_delta_person_smokes;
-          TRUNCATE dd_new_person_smokes;
-          TRUNCATE dd_new_friends;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_dd_delta_smoke {
         sql: """ 
         INSERT INTO dd_delta_smoke SELECT DISTINCT R0.person_id, 0 AS id, R0.smokes AS label
@@ -143,8 +35,12 @@ dd_delta_smoke.label: Boolean
         
           
         """
+          output_relation: "dd_delta_smoke"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_delta_person_smokes
+          ]
       }
     
 
@@ -158,8 +54,13 @@ SELECT R0.person_id, R0.has_cancer
 FROM dd_delta_person_has_cancer R0
         
         """
+          output_relation: "dd_new_person_has_cancer"
         style: "sql_extractor"
           
+          input_relations: [
+            person_has_cancer
+            dd_delta_person_has_cancer
+          ]
       }
     
 
@@ -173,8 +74,13 @@ SELECT R0.person_id, R0.name
 FROM dd_delta_person R0
         
         """
+          output_relation: "dd_new_person"
         style: "sql_extractor"
           
+          input_relations: [
+            person
+            dd_delta_person
+          ]
       }
     
 
@@ -190,8 +96,13 @@ SELECT DISTINCT R0.person_id, id, label
         
           
         """
+          output_relation: "dd_new_smoke"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_smoke" ]
+          input_relations: [
+            smoke
+            dd_delta_smoke
+          ]
       }
     
 
@@ -202,8 +113,12 @@ SELECT DISTINCT R0.person_id, id, label
         
           
         """
+          output_relation: "dd_delta_cancer"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_delta_person_has_cancer
+          ]
       }
     
 
@@ -219,8 +134,13 @@ SELECT DISTINCT R0.person_id, id, label
         
           
         """
+          output_relation: "dd_new_cancer"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_cancer" ]
+          input_relations: [
+            cancer
+            dd_delta_cancer
+          ]
       }
     
 
@@ -234,8 +154,13 @@ SELECT R0.person_id, R0.smokes
 FROM dd_delta_person_smokes R0
         
         """
+          output_relation: "dd_new_person_smokes"
         style: "sql_extractor"
           
+          input_relations: [
+            person_smokes
+            dd_delta_person_smokes
+          ]
       }
     
 
@@ -249,8 +174,13 @@ SELECT R0.person_id, R0.friend_id
 FROM dd_delta_friends R0
         
         """
+          output_relation: "dd_new_friends"
         style: "sql_extractor"
           
+          input_relations: [
+            friends
+            dd_delta_friends
+          ]
       }
     
 
@@ -261,6 +191,12 @@ FROM dd_delta_friends R0
         WHERE R1.person_id = R0.person_id  AND R2.person_id = R0.person_id """
           function: "Imply(dd_new_smoke.R0.label, dd_new_cancer.R1.label)"
           weight: "0.5"
+          
+          input_relations: [
+            dd_new_smoke
+            dd_new_cancer
+            dd_delta_person_smokes
+          ]
         }
       
 
@@ -271,23 +207,14 @@ FROM dd_delta_friends R0
         WHERE R2.person_id = R0.person_id  AND R2.friend_id = R1.person_id """
           function: "Imply(dd_new_smoke.R0.label, dd_new_smoke.R1.label)"
           weight: "0.4"
+          
+          input_relations: [
+            dd_new_smoke
+            dd_delta_friends
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_dd_delta_friends
-  init_dd_delta_smoke
-  init_dd_new_person_has_cancer
-  init_dd_delta_person
-  init_dd_new_person
-  init_dd_delta_person_has_cancer
-  init_dd_new_smoke
-  init_dd_delta_cancer
-  init_dd_new_cancer
-  init_dd_delta_person_smokes
-  init_dd_new_person_smokes
-  init_dd_new_friends
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_dd_delta_cancer
   ext_dd_delta_smoke
@@ -313,8 +240,5 @@ deepdive.pipeline.pipelines.endtoend: [
   ext_dd_new_smoke
   dd_delta_inf_imply_smoke_cancer
   dd_delta_inf_imply_smoke_smoke
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]
 deepdive.pipeline.base_dir: ${BASEDIR}

--- a/test/expected-output-test/smoke_example/compile-materialization.expected
+++ b/test/expected-output-test/smoke_example/compile-materialization.expected
@@ -18,74 +18,6 @@ cancer.label: Boolean
       }
     
 
-          deepdive.extraction.extractors.init_person_smokes {
-            sql: """ DROP TABLE IF EXISTS person_smokes CASCADE;
-            CREATE TABLE
-            person_smokes(person_id bigint,
-             smokes boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_smoke {
-            sql: """ DROP TABLE IF EXISTS smoke CASCADE;
-            CREATE TABLE
-            smoke(person_id bigint,
-     id bigint,
-     label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_cancer {
-            sql: """ DROP TABLE IF EXISTS cancer CASCADE;
-            CREATE TABLE
-            cancer(person_id bigint,
-      id bigint,
-      label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_friends {
-            sql: """ DROP TABLE IF EXISTS friends CASCADE;
-            CREATE TABLE
-            friends(person_id bigint,
-       friend_id bigint)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_person_has_cancer {
-            sql: """ DROP TABLE IF EXISTS person_has_cancer CASCADE;
-            CREATE TABLE
-            person_has_cancer(person_id bigint,
-                 has_cancer boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_person {
-            sql: """ DROP TABLE IF EXISTS person CASCADE;
-            CREATE TABLE
-            person(person_id bigint,
-      name text)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE person_smokes;
-          TRUNCATE smoke;
-          TRUNCATE cancer;
-          TRUNCATE friends;
-          TRUNCATE person_has_cancer;
-          TRUNCATE person;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_cancer {
         sql: """ 
         INSERT INTO cancer SELECT DISTINCT R0.person_id, 0 AS id, R0.has_cancer AS label
@@ -93,8 +25,12 @@ cancer.label: Boolean
         
           
         """
+          output_relation: "cancer"
         style: "sql_extractor"
           
+          input_relations: [
+            person_has_cancer
+          ]
       }
     
 
@@ -105,8 +41,12 @@ cancer.label: Boolean
         
           
         """
+          output_relation: "smoke"
         style: "sql_extractor"
           
+          input_relations: [
+            person_smokes
+          ]
       }
     
 
@@ -117,6 +57,12 @@ cancer.label: Boolean
         WHERE R1.person_id = R0.person_id  AND R2.person_id = R0.person_id """
           function: "Imply(smoke.R0.label, cancer.R1.label)"
           weight: "0.5"
+          
+          input_relations: [
+            smoke
+            cancer
+            person_smokes
+          ]
         }
       
 
@@ -127,17 +73,14 @@ cancer.label: Boolean
         WHERE R2.person_id = R0.person_id  AND R2.friend_id = R1.person_id """
           function: "Imply(smoke.R0.label, smoke.R1.label)"
           weight: "0.4"
+          
+          input_relations: [
+            smoke
+            friends
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_person_smokes
-  init_smoke
-  init_cancer
-  init_friends
-  init_person_has_cancer
-  init_person
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_cancer
   ext_smoke

--- a/test/expected-output-test/smoke_example/compile-merge.expected
+++ b/test/expected-output-test/smoke_example/compile-merge.expected
@@ -23,8 +23,12 @@
 FROM dd_new_person_smokes R0
         
         """
+          output_relation: "person_smokes"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_new_person_smokes
+          ]
       }
     
 
@@ -34,8 +38,12 @@ FROM dd_new_person_smokes R0
 FROM dd_new_friends R0
         
         """
+          output_relation: "friends"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_new_friends
+          ]
       }
     
 
@@ -45,8 +53,12 @@ FROM dd_new_friends R0
 FROM dd_new_person_has_cancer R0
         
         """
+          output_relation: "person_has_cancer"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_new_person_has_cancer
+          ]
       }
     
 
@@ -56,8 +68,12 @@ FROM dd_new_person_has_cancer R0
 FROM dd_new_person R0
         
         """
+          output_relation: "person"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_new_person
+          ]
       }
     
 deepdive.pipeline.run: ${PIPELINE}

--- a/test/expected-output-test/smoke_example/compile.expected
+++ b/test/expected-output-test/smoke_example/compile.expected
@@ -18,74 +18,6 @@ cancer.label: Boolean
       }
     
 
-          deepdive.extraction.extractors.init_person_smokes {
-            sql: """ DROP TABLE IF EXISTS person_smokes CASCADE;
-            CREATE TABLE
-            person_smokes(person_id bigint,
-             smokes boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_smoke {
-            sql: """ DROP TABLE IF EXISTS smoke CASCADE;
-            CREATE TABLE
-            smoke(person_id bigint,
-     id bigint,
-     label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_cancer {
-            sql: """ DROP TABLE IF EXISTS cancer CASCADE;
-            CREATE TABLE
-            cancer(person_id bigint,
-      id bigint,
-      label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_friends {
-            sql: """ DROP TABLE IF EXISTS friends CASCADE;
-            CREATE TABLE
-            friends(person_id bigint,
-       friend_id bigint)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_person_has_cancer {
-            sql: """ DROP TABLE IF EXISTS person_has_cancer CASCADE;
-            CREATE TABLE
-            person_has_cancer(person_id bigint,
-                 has_cancer boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_person {
-            sql: """ DROP TABLE IF EXISTS person CASCADE;
-            CREATE TABLE
-            person(person_id bigint,
-      name text)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE person_smokes;
-          TRUNCATE smoke;
-          TRUNCATE cancer;
-          TRUNCATE friends;
-          TRUNCATE person_has_cancer;
-          TRUNCATE person;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_cancer {
         sql: """ 
         INSERT INTO cancer SELECT DISTINCT R0.person_id, 0 AS id, R0.has_cancer AS label
@@ -93,8 +25,12 @@ cancer.label: Boolean
         
           
         """
+          output_relation: "cancer"
         style: "sql_extractor"
           
+          input_relations: [
+            person_has_cancer
+          ]
       }
     
 
@@ -105,8 +41,12 @@ cancer.label: Boolean
         
           
         """
+          output_relation: "smoke"
         style: "sql_extractor"
           
+          input_relations: [
+            person_smokes
+          ]
       }
     
 
@@ -117,6 +57,12 @@ cancer.label: Boolean
         WHERE R1.person_id = R0.person_id  AND R2.person_id = R0.person_id """
           function: "Imply(smoke.R0.label, cancer.R1.label)"
           weight: "0.5"
+          
+          input_relations: [
+            smoke
+            cancer
+            person_smokes
+          ]
         }
       
 
@@ -127,17 +73,14 @@ cancer.label: Boolean
         WHERE R2.person_id = R0.person_id  AND R2.friend_id = R1.person_id """
           function: "Imply(smoke.R0.label, smoke.R1.label)"
           weight: "0.4"
+          
+          input_relations: [
+            smoke
+            friends
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_person_smokes
-  init_smoke
-  init_cancer
-  init_friends
-  init_person_has_cancer
-  init_person
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_cancer
   ext_smoke
@@ -151,7 +94,4 @@ deepdive.pipeline.pipelines.endtoend: [
   ext_smoke
   inf_imply_smoke_cancer
   inf_imply_smoke_smoke
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]

--- a/test/expected-output-test/spouse_example/compile-incremental.expected
+++ b/test/expected-output-test/spouse_example/compile-incremental.expected
@@ -23,6 +23,151 @@ dd_new_has_spouse.label: Boolean
       }
     
 
+          deepdive.extraction.extractors.init_dd_delta_articles {
+            sql: """ DROP TABLE IF EXISTS dd_delta_articles CASCADE;
+            CREATE TABLE
+            dd_delta_articles(article_id text,
+                 text text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_people_mentions {
+            sql: """ DROP TABLE IF EXISTS dd_new_people_mentions CASCADE;
+            CREATE TABLE
+            dd_new_people_mentions(sentence_id text,
+                      start_position int,
+                      length int,
+                      text text,
+                      mention_id text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_has_spouse_features {
+            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse_features CASCADE;
+            CREATE TABLE
+            dd_delta_has_spouse_features(relation_id text,
+                            feature text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_articles {
+            sql: """ DROP TABLE IF EXISTS dd_new_articles CASCADE;
+            CREATE TABLE
+            dd_new_articles(article_id text,
+               text text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_has_spouse_candidates {
+            sql: """ DROP TABLE IF EXISTS dd_new_has_spouse_candidates CASCADE;
+            CREATE TABLE
+            dd_new_has_spouse_candidates(person1_id text,
+                            person2_id text,
+                            sentence_id text,
+                            description text,
+                            relation_id text,
+                            is_true boolean)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_has_spouse_features {
+            sql: """ DROP TABLE IF EXISTS dd_new_has_spouse_features CASCADE;
+            CREATE TABLE
+            dd_new_has_spouse_features(relation_id text,
+                          feature text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_sentences {
+            sql: """ DROP TABLE IF EXISTS dd_new_sentences CASCADE;
+            CREATE TABLE
+            dd_new_sentences(document_id text,
+                sentence text,
+                words text[],
+                lemma text[],
+                pos_tags text[],
+                dependencies text[],
+                ner_tags text[],
+                sentence_offset int,
+                sentence_id text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_people_mentions {
+            sql: """ DROP TABLE IF EXISTS dd_delta_people_mentions CASCADE;
+            CREATE TABLE
+            dd_delta_people_mentions(sentence_id text,
+                        start_position int,
+                        length int,
+                        text text,
+                        mention_id text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_has_spouse_candidates {
+            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse_candidates CASCADE;
+            CREATE TABLE
+            dd_delta_has_spouse_candidates(person1_id text,
+                              person2_id text,
+                              sentence_id text,
+                              description text,
+                              relation_id text,
+                              is_true boolean)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_sentences {
+            sql: """ DROP TABLE IF EXISTS dd_delta_sentences CASCADE;
+            CREATE TABLE
+            dd_delta_sentences(document_id text,
+                  sentence text,
+                  words text[],
+                  lemma text[],
+                  pos_tags text[],
+                  dependencies text[],
+                  ner_tags text[],
+                  sentence_offset int,
+                  sentence_id text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_has_spouse {
+            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse CASCADE;
+            CREATE TABLE
+            dd_delta_has_spouse(relation_id text,
+                   id bigint,
+                   label boolean)
+            """
+            style: "sql_extractor"
+          }
+
+        deepdive.extraction.extractors.cleanup {
+          sql: """
+          TRUNCATE dd_delta_articles;
+          TRUNCATE dd_new_people_mentions;
+          TRUNCATE dd_delta_has_spouse_features;
+          TRUNCATE dd_new_articles;
+          TRUNCATE dd_new_has_spouse_candidates;
+          TRUNCATE dd_new_has_spouse_features;
+          TRUNCATE dd_new_sentences;
+          TRUNCATE dd_delta_people_mentions;
+          TRUNCATE dd_delta_has_spouse_candidates;
+          TRUNCATE dd_delta_sentences;
+          TRUNCATE dd_delta_has_spouse;
+          """
+          style: "sql_extractor"
+        }
+
       deepdive.extraction.extractors.ext_dd_new_people_mentions {
         sql: """ TRUNCATE dd_new_people_mentions;
         INSERT INTO dd_new_people_mentions SELECT R0.sentence_id, R0.start_position, R0.length, R0.text, R0.mention_id
@@ -287,3 +432,20 @@ deepdive.pipeline.pipelines.endtoend: [
   dd_delta_inf_istrue_has_spouse
 ]
 deepdive.pipeline.base_dir: ${BASEDIR}
+deepdive.pipeline.pipelines.initdb: [
+  init_dd_delta_articles
+  init_dd_new_people_mentions
+  init_dd_delta_has_spouse_features
+  init_dd_new_articles
+  init_dd_new_has_spouse_candidates
+  init_dd_new_has_spouse_features
+  init_dd_new_sentences
+  init_dd_delta_people_mentions
+  init_dd_delta_has_spouse_candidates
+  init_dd_delta_sentences
+  init_dd_delta_has_spouse
+  init_dd_new_has_spouse
+]
+deepdive.pipeline.pipelines.cleanup: [
+  cleanup
+]

--- a/test/expected-output-test/spouse_example/compile-incremental.expected
+++ b/test/expected-output-test/spouse_example/compile-incremental.expected
@@ -23,151 +23,6 @@ dd_new_has_spouse.label: Boolean
       }
     
 
-          deepdive.extraction.extractors.init_dd_delta_articles {
-            sql: """ DROP TABLE IF EXISTS dd_delta_articles CASCADE;
-            CREATE TABLE
-            dd_delta_articles(article_id text,
-                 text text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_people_mentions {
-            sql: """ DROP TABLE IF EXISTS dd_new_people_mentions CASCADE;
-            CREATE TABLE
-            dd_new_people_mentions(sentence_id text,
-                      start_position int,
-                      length int,
-                      text text,
-                      mention_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_has_spouse_features {
-            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse_features CASCADE;
-            CREATE TABLE
-            dd_delta_has_spouse_features(relation_id text,
-                            feature text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_articles {
-            sql: """ DROP TABLE IF EXISTS dd_new_articles CASCADE;
-            CREATE TABLE
-            dd_new_articles(article_id text,
-               text text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_has_spouse_candidates {
-            sql: """ DROP TABLE IF EXISTS dd_new_has_spouse_candidates CASCADE;
-            CREATE TABLE
-            dd_new_has_spouse_candidates(person1_id text,
-                            person2_id text,
-                            sentence_id text,
-                            description text,
-                            relation_id text,
-                            is_true boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_has_spouse_features {
-            sql: """ DROP TABLE IF EXISTS dd_new_has_spouse_features CASCADE;
-            CREATE TABLE
-            dd_new_has_spouse_features(relation_id text,
-                          feature text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_sentences {
-            sql: """ DROP TABLE IF EXISTS dd_new_sentences CASCADE;
-            CREATE TABLE
-            dd_new_sentences(document_id text,
-                sentence text,
-                words text[],
-                lemma text[],
-                pos_tags text[],
-                dependencies text[],
-                ner_tags text[],
-                sentence_offset int,
-                sentence_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_people_mentions {
-            sql: """ DROP TABLE IF EXISTS dd_delta_people_mentions CASCADE;
-            CREATE TABLE
-            dd_delta_people_mentions(sentence_id text,
-                        start_position int,
-                        length int,
-                        text text,
-                        mention_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_has_spouse_candidates {
-            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse_candidates CASCADE;
-            CREATE TABLE
-            dd_delta_has_spouse_candidates(person1_id text,
-                              person2_id text,
-                              sentence_id text,
-                              description text,
-                              relation_id text,
-                              is_true boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_sentences {
-            sql: """ DROP TABLE IF EXISTS dd_delta_sentences CASCADE;
-            CREATE TABLE
-            dd_delta_sentences(document_id text,
-                  sentence text,
-                  words text[],
-                  lemma text[],
-                  pos_tags text[],
-                  dependencies text[],
-                  ner_tags text[],
-                  sentence_offset int,
-                  sentence_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_has_spouse {
-            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse CASCADE;
-            CREATE TABLE
-            dd_delta_has_spouse(relation_id text,
-                   id bigint,
-                   label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE dd_delta_articles;
-          TRUNCATE dd_new_people_mentions;
-          TRUNCATE dd_delta_has_spouse_features;
-          TRUNCATE dd_new_articles;
-          TRUNCATE dd_new_has_spouse_candidates;
-          TRUNCATE dd_new_has_spouse_features;
-          TRUNCATE dd_new_sentences;
-          TRUNCATE dd_delta_people_mentions;
-          TRUNCATE dd_delta_has_spouse_candidates;
-          TRUNCATE dd_delta_sentences;
-          TRUNCATE dd_delta_has_spouse;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_dd_new_people_mentions {
         sql: """ TRUNCATE dd_new_people_mentions;
         INSERT INTO dd_new_people_mentions SELECT R0.sentence_id, R0.start_position, R0.length, R0.text, R0.mention_id
@@ -178,8 +33,13 @@ SELECT R0.sentence_id, R0.start_position, R0.length, R0.text, R0.mention_id
 FROM dd_delta_people_mentions R0
         
         """
+          output_relation: "dd_new_people_mentions"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_people_mentions_by_ext_people" ]
+          input_relations: [
+            people_mentions
+            dd_delta_people_mentions
+          ]
       }
     
 
@@ -193,8 +53,13 @@ SELECT R0.article_id, R0.text
 FROM dd_delta_articles R0
         
         """
+          output_relation: "dd_new_articles"
         style: "sql_extractor"
           
+          input_relations: [
+            articles
+            dd_delta_articles
+          ]
       }
     
 
@@ -208,8 +73,13 @@ SELECT R0.person1_id, R0.person2_id, R0.sentence_id, R0.description, R0.relation
 FROM dd_delta_has_spouse_candidates R0
         
         """
+          output_relation: "dd_new_has_spouse_candidates"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_has_spouse_candidates_by_ext_has_spouse" ]
+          input_relations: [
+            has_spouse_candidates
+            dd_delta_has_spouse_candidates
+          ]
       }
     
 
@@ -223,8 +93,13 @@ SELECT R0.relation_id, R0.feature
 FROM dd_delta_has_spouse_features R0
         
         """
+          output_relation: "dd_new_has_spouse_features"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_has_spouse_features_by_ext_has_spouse_features" ]
+          input_relations: [
+            has_spouse_features
+            dd_delta_has_spouse_features
+          ]
       }
     
 
@@ -238,8 +113,13 @@ SELECT R0.document_id, R0.sentence, R0.words, R0.lemma, R0.pos_tags, R0.dependen
 FROM dd_delta_sentences R0
         
         """
+          output_relation: "dd_new_sentences"
         style: "sql_extractor"
           
+          input_relations: [
+            sentences
+            dd_delta_sentences
+          ]
       }
     
 
@@ -250,8 +130,12 @@ FROM dd_delta_sentences R0
         
           
         """
+          output_relation: "dd_delta_has_spouse"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_has_spouse_candidates_by_ext_has_spouse" ]
+          input_relations: [
+            dd_delta_has_spouse_candidates
+          ]
       }
     
 
@@ -267,8 +151,13 @@ SELECT DISTINCT R0.relation_id, id, label
         
           
         """
+          output_relation: "dd_new_has_spouse"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_has_spouse" ]
+          input_relations: [
+            has_spouse
+            dd_delta_has_spouse
+          ]
       }
     
 
@@ -281,7 +170,10 @@ FROM dd_delta_sentences R0
           udf: ${APP_HOME}"/udf/ext_people.py"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            dd_delta_sentences
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -299,7 +191,12 @@ FROM dd_new_people_mentions R0, dd_delta_people_mentions R1
           udf: ${APP_HOME}"/udf/ext_has_spouse.py"
           style: "tsv_extractor" 
           dependencies: [ "ext_dd_delta_people_mentions_by_ext_people" ,  "ext_dd_new_people_mentions" ]
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            dd_delta_people_mentions
+            people_mentions
+            dd_new_people_mentions
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -325,7 +222,17 @@ FROM dd_new_sentences R0, dd_new_has_spouse_candidates R1, dd_new_people_mention
           udf: ${APP_HOME}"/udf/ext_has_spouse_features.py"
           style: "tsv_extractor" 
           dependencies: [ "ext_dd_delta_has_spouse_candidates_by_ext_has_spouse" ,  "ext_dd_new_sentences" ,  "ext_dd_delta_people_mentions_by_ext_people" ,  "ext_dd_new_people_mentions" ,  "ext_dd_new_has_spouse_candidates" ]
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            dd_delta_sentences
+            has_spouse_candidates
+            people_mentions
+            dd_new_sentences
+            dd_delta_has_spouse_candidates
+            dd_new_has_spouse_candidates
+            dd_delta_people_mentions
+            dd_new_people_mentions
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -340,23 +247,17 @@ FROM dd_new_sentences R0, dd_new_has_spouse_candidates R1, dd_new_people_mention
         WHERE R1.relation_id = R0.relation_id  AND R2.relation_id = R0.relation_id """
           function: "Imply(dd_new_has_spouse.R0.label)"
           weight: "?(dd_weight_column_0)"
+          dependencies: [ "ext_dd_delta_has_spouse_candidates_by_ext_has_spouse" ,  "ext_dd_new_has_spouse_candidates" ,  "ext_dd_delta_has_spouse_features_by_ext_has_spouse_features" ]
+          input_relations: [
+            dd_new_has_spouse
+            dd_delta_has_spouse_candidates
+            has_spouse_features
+            dd_new_has_spouse_candidates
+            dd_delta_has_spouse_features
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_dd_delta_articles
-  init_dd_new_people_mentions
-  init_dd_delta_has_spouse_features
-  init_dd_new_articles
-  init_dd_new_has_spouse_candidates
-  init_dd_new_has_spouse_features
-  init_dd_new_sentences
-  init_dd_delta_people_mentions
-  init_dd_delta_has_spouse_candidates
-  init_dd_delta_sentences
-  init_dd_delta_has_spouse
-  init_dd_new_has_spouse
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_dd_new_has_spouse_candidates
   ext_dd_delta_has_spouse_candidates_by_ext_has_spouse
@@ -384,8 +285,5 @@ deepdive.pipeline.pipelines.endtoend: [
   ext_dd_new_sentences
   ext_dd_new_articles
   dd_delta_inf_istrue_has_spouse
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]
 deepdive.pipeline.base_dir: ${BASEDIR}

--- a/test/expected-output-test/spouse_example/compile-materialization.expected
+++ b/test/expected-output-test/spouse_example/compile-materialization.expected
@@ -17,87 +17,6 @@
       }
     
 
-          deepdive.extraction.extractors.init_sentences {
-            sql: """ DROP TABLE IF EXISTS sentences CASCADE;
-            CREATE TABLE
-            sentences(document_id text,
-         sentence text,
-         words text[],
-         lemma text[],
-         pos_tags text[],
-         dependencies text[],
-         ner_tags text[],
-         sentence_offset int,
-         sentence_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_has_spouse_candidates {
-            sql: """ DROP TABLE IF EXISTS has_spouse_candidates CASCADE;
-            CREATE TABLE
-            has_spouse_candidates(person1_id text,
-                     person2_id text,
-                     sentence_id text,
-                     description text,
-                     relation_id text,
-                     is_true boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_has_spouse {
-            sql: """ DROP TABLE IF EXISTS has_spouse CASCADE;
-            CREATE TABLE
-            has_spouse(relation_id text,
-          id bigint,
-          label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_articles {
-            sql: """ DROP TABLE IF EXISTS articles CASCADE;
-            CREATE TABLE
-            articles(article_id text,
-        text text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_has_spouse_features {
-            sql: """ DROP TABLE IF EXISTS has_spouse_features CASCADE;
-            CREATE TABLE
-            has_spouse_features(relation_id text,
-                   feature text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_people_mentions {
-            sql: """ DROP TABLE IF EXISTS people_mentions CASCADE;
-            CREATE TABLE
-            people_mentions(sentence_id text,
-               start_position int,
-               length int,
-               text text,
-               mention_id text)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE sentences;
-          TRUNCATE has_spouse_candidates;
-          TRUNCATE has_spouse;
-          TRUNCATE articles;
-          TRUNCATE has_spouse_features;
-          TRUNCATE people_mentions;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_has_spouse {
         sql: """ 
         INSERT INTO has_spouse SELECT DISTINCT R0.relation_id, 0 AS id, R0.is_true AS label
@@ -105,8 +24,12 @@
         
           
         """
+          output_relation: "has_spouse"
         style: "sql_extractor"
           dependencies: [ "ext_has_spouse_candidates_by_ext_has_spouse" ]
+          input_relations: [
+            has_spouse_candidates
+          ]
       }
     
 
@@ -119,7 +42,10 @@ FROM sentences R0
           udf: ${APP_HOME}"/udf/ext_people.py"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            sentences
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -133,7 +59,10 @@ FROM people_mentions R0, people_mentions R1
           udf: ${APP_HOME}"/udf/ext_has_spouse.py"
           style: "tsv_extractor" 
           dependencies: [ "ext_people_mentions_by_ext_people" ]
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            people_mentions
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -147,7 +76,12 @@ FROM sentences R0, has_spouse_candidates R1, people_mentions R2, people_mentions
           udf: ${APP_HOME}"/udf/ext_has_spouse_features.py"
           style: "tsv_extractor" 
           dependencies: [ "ext_has_spouse_candidates_by_ext_has_spouse" ,  "ext_people_mentions_by_ext_people" ]
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            sentences
+            has_spouse_candidates
+            people_mentions
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -159,17 +93,15 @@ FROM sentences R0, has_spouse_candidates R1, people_mentions R2, people_mentions
         WHERE R1.relation_id = R0.relation_id  AND R2.relation_id = R0.relation_id """
           function: "Imply(has_spouse.R0.label)"
           weight: "?(dd_weight_column_0)"
+          dependencies: [ "ext_has_spouse_candidates_by_ext_has_spouse" ,  "ext_has_spouse_features_by_ext_has_spouse_features" ]
+          input_relations: [
+            has_spouse
+            has_spouse_candidates
+            has_spouse_features
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_sentences
-  init_has_spouse_candidates
-  init_has_spouse
-  init_articles
-  init_has_spouse_features
-  init_people_mentions
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_has_spouse
   ext_people_mentions_by_ext_people

--- a/test/expected-output-test/spouse_example/compile-merge.expected
+++ b/test/expected-output-test/spouse_example/compile-merge.expected
@@ -23,8 +23,12 @@
 FROM dd_new_sentences R0
         
         """
+          output_relation: "sentences"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_new_sentences
+          ]
       }
     
 
@@ -34,8 +38,12 @@ FROM dd_new_sentences R0
 FROM dd_new_has_spouse_candidates R0
         
         """
+          output_relation: "has_spouse_candidates"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_new_has_spouse_candidates
+          ]
       }
     
 
@@ -45,8 +53,12 @@ FROM dd_new_has_spouse_candidates R0
 FROM dd_new_articles R0
         
         """
+          output_relation: "articles"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_new_articles
+          ]
       }
     
 
@@ -56,8 +68,12 @@ FROM dd_new_articles R0
 FROM dd_new_has_spouse_features R0
         
         """
+          output_relation: "has_spouse_features"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_new_has_spouse_features
+          ]
       }
     
 
@@ -67,8 +83,12 @@ FROM dd_new_has_spouse_features R0
 FROM dd_new_people_mentions R0
         
         """
+          output_relation: "people_mentions"
         style: "sql_extractor"
           
+          input_relations: [
+            dd_new_people_mentions
+          ]
       }
     
 deepdive.pipeline.run: ${PIPELINE}

--- a/test/expected-output-test/spouse_example/compile.expected
+++ b/test/expected-output-test/spouse_example/compile.expected
@@ -17,87 +17,6 @@
       }
     
 
-          deepdive.extraction.extractors.init_sentences {
-            sql: """ DROP TABLE IF EXISTS sentences CASCADE;
-            CREATE TABLE
-            sentences(document_id text,
-         sentence text,
-         words text[],
-         lemma text[],
-         pos_tags text[],
-         dependencies text[],
-         ner_tags text[],
-         sentence_offset int,
-         sentence_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_has_spouse_candidates {
-            sql: """ DROP TABLE IF EXISTS has_spouse_candidates CASCADE;
-            CREATE TABLE
-            has_spouse_candidates(person1_id text,
-                     person2_id text,
-                     sentence_id text,
-                     description text,
-                     relation_id text,
-                     is_true boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_has_spouse {
-            sql: """ DROP TABLE IF EXISTS has_spouse CASCADE;
-            CREATE TABLE
-            has_spouse(relation_id text,
-          id bigint,
-          label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_articles {
-            sql: """ DROP TABLE IF EXISTS articles CASCADE;
-            CREATE TABLE
-            articles(article_id text,
-        text text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_has_spouse_features {
-            sql: """ DROP TABLE IF EXISTS has_spouse_features CASCADE;
-            CREATE TABLE
-            has_spouse_features(relation_id text,
-                   feature text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_people_mentions {
-            sql: """ DROP TABLE IF EXISTS people_mentions CASCADE;
-            CREATE TABLE
-            people_mentions(sentence_id text,
-               start_position int,
-               length int,
-               text text,
-               mention_id text)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE sentences;
-          TRUNCATE has_spouse_candidates;
-          TRUNCATE has_spouse;
-          TRUNCATE articles;
-          TRUNCATE has_spouse_features;
-          TRUNCATE people_mentions;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_has_spouse {
         sql: """ 
         INSERT INTO has_spouse SELECT DISTINCT R0.relation_id, 0 AS id, R0.is_true AS label
@@ -105,8 +24,12 @@
         
           
         """
+          output_relation: "has_spouse"
         style: "sql_extractor"
           dependencies: [ "ext_has_spouse_candidates_by_ext_has_spouse" ]
+          input_relations: [
+            has_spouse_candidates
+          ]
       }
     
 
@@ -119,7 +42,10 @@ FROM sentences R0
           udf: ${APP_HOME}"/udf/ext_people.py"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            sentences
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -133,7 +59,10 @@ FROM people_mentions R0, people_mentions R1
           udf: ${APP_HOME}"/udf/ext_has_spouse.py"
           style: "tsv_extractor" 
           dependencies: [ "ext_people_mentions_by_ext_people" ]
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            people_mentions
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -147,7 +76,12 @@ FROM sentences R0, has_spouse_candidates R1, people_mentions R2, people_mentions
           udf: ${APP_HOME}"/udf/ext_has_spouse_features.py"
           style: "tsv_extractor" 
           dependencies: [ "ext_has_spouse_candidates_by_ext_has_spouse" ,  "ext_people_mentions_by_ext_people" ]
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            sentences
+            has_spouse_candidates
+            people_mentions
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -159,17 +93,15 @@ FROM sentences R0, has_spouse_candidates R1, people_mentions R2, people_mentions
         WHERE R1.relation_id = R0.relation_id  AND R2.relation_id = R0.relation_id """
           function: "Imply(has_spouse.R0.label)"
           weight: "?(dd_weight_column_0)"
+          dependencies: [ "ext_has_spouse_candidates_by_ext_has_spouse" ,  "ext_has_spouse_features_by_ext_has_spouse_features" ]
+          input_relations: [
+            has_spouse
+            has_spouse_candidates
+            has_spouse_features
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_sentences
-  init_has_spouse_candidates
-  init_has_spouse
-  init_articles
-  init_has_spouse_features
-  init_people_mentions
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_has_spouse
   ext_people_mentions_by_ext_people
@@ -185,7 +117,4 @@ deepdive.pipeline.pipelines.endtoend: [
   ext_has_spouse_candidates_by_ext_has_spouse
   ext_has_spouse_features_by_ext_has_spouse_features
   inf_istrue_has_spouse
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]

--- a/test/expected-output-test/spouse_example_new_feature/compile-incremental.expected
+++ b/test/expected-output-test/spouse_example_new_feature/compile-incremental.expected
@@ -23,6 +23,151 @@ dd_new_has_spouse.label: Boolean
       }
     
 
+          deepdive.extraction.extractors.init_dd_delta_articles {
+            sql: """ DROP TABLE IF EXISTS dd_delta_articles CASCADE;
+            CREATE TABLE
+            dd_delta_articles(article_id text,
+                 text text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_people_mentions {
+            sql: """ DROP TABLE IF EXISTS dd_new_people_mentions CASCADE;
+            CREATE TABLE
+            dd_new_people_mentions(sentence_id text,
+                      start_position int,
+                      length int,
+                      text text,
+                      mention_id text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_has_spouse_features {
+            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse_features CASCADE;
+            CREATE TABLE
+            dd_delta_has_spouse_features(relation_id text,
+                            feature text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_articles {
+            sql: """ DROP TABLE IF EXISTS dd_new_articles CASCADE;
+            CREATE TABLE
+            dd_new_articles(article_id text,
+               text text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_has_spouse_candidates {
+            sql: """ DROP TABLE IF EXISTS dd_new_has_spouse_candidates CASCADE;
+            CREATE TABLE
+            dd_new_has_spouse_candidates(person1_id text,
+                            person2_id text,
+                            sentence_id text,
+                            description text,
+                            relation_id text,
+                            is_true boolean)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_has_spouse_features {
+            sql: """ DROP TABLE IF EXISTS dd_new_has_spouse_features CASCADE;
+            CREATE TABLE
+            dd_new_has_spouse_features(relation_id text,
+                          feature text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_sentences {
+            sql: """ DROP TABLE IF EXISTS dd_new_sentences CASCADE;
+            CREATE TABLE
+            dd_new_sentences(document_id text,
+                sentence text,
+                words text[],
+                lemma text[],
+                pos_tags text[],
+                dependencies text[],
+                ner_tags text[],
+                sentence_offset int,
+                sentence_id text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_people_mentions {
+            sql: """ DROP TABLE IF EXISTS dd_delta_people_mentions CASCADE;
+            CREATE TABLE
+            dd_delta_people_mentions(sentence_id text,
+                        start_position int,
+                        length int,
+                        text text,
+                        mention_id text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_has_spouse_candidates {
+            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse_candidates CASCADE;
+            CREATE TABLE
+            dd_delta_has_spouse_candidates(person1_id text,
+                              person2_id text,
+                              sentence_id text,
+                              description text,
+                              relation_id text,
+                              is_true boolean)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_sentences {
+            sql: """ DROP TABLE IF EXISTS dd_delta_sentences CASCADE;
+            CREATE TABLE
+            dd_delta_sentences(document_id text,
+                  sentence text,
+                  words text[],
+                  lemma text[],
+                  pos_tags text[],
+                  dependencies text[],
+                  ner_tags text[],
+                  sentence_offset int,
+                  sentence_id text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_has_spouse {
+            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse CASCADE;
+            CREATE TABLE
+            dd_delta_has_spouse(relation_id text,
+                   id bigint,
+                   label boolean)
+            """
+            style: "sql_extractor"
+          }
+
+        deepdive.extraction.extractors.cleanup {
+          sql: """
+          TRUNCATE dd_delta_articles;
+          TRUNCATE dd_new_people_mentions;
+          TRUNCATE dd_delta_has_spouse_features;
+          TRUNCATE dd_new_articles;
+          TRUNCATE dd_new_has_spouse_candidates;
+          TRUNCATE dd_new_has_spouse_features;
+          TRUNCATE dd_new_sentences;
+          TRUNCATE dd_delta_people_mentions;
+          TRUNCATE dd_delta_has_spouse_candidates;
+          TRUNCATE dd_delta_sentences;
+          TRUNCATE dd_delta_has_spouse;
+          """
+          style: "sql_extractor"
+        }
+
       deepdive.extraction.extractors.ext_dd_new_people_mentions {
         sql: """ TRUNCATE dd_new_people_mentions;
         INSERT INTO dd_new_people_mentions SELECT R0.sentence_id, R0.start_position, R0.length, R0.text, R0.mention_id
@@ -292,3 +437,20 @@ deepdive.pipeline.pipelines.endtoend: [
   dd_delta_inf_istrue_has_spouse
 ]
 deepdive.pipeline.base_dir: ${BASEDIR}
+deepdive.pipeline.pipelines.initdb: [
+  init_dd_delta_articles
+  init_dd_new_people_mentions
+  init_dd_delta_has_spouse_features
+  init_dd_new_articles
+  init_dd_new_has_spouse_candidates
+  init_dd_new_has_spouse_features
+  init_dd_new_sentences
+  init_dd_delta_people_mentions
+  init_dd_delta_has_spouse_candidates
+  init_dd_delta_sentences
+  init_dd_delta_has_spouse
+  init_dd_new_has_spouse
+]
+deepdive.pipeline.pipelines.cleanup: [
+  cleanup
+]

--- a/test/expected-output-test/spouse_example_new_feature/compile-incremental.expected
+++ b/test/expected-output-test/spouse_example_new_feature/compile-incremental.expected
@@ -23,151 +23,6 @@ dd_new_has_spouse.label: Boolean
       }
     
 
-          deepdive.extraction.extractors.init_dd_delta_articles {
-            sql: """ DROP TABLE IF EXISTS dd_delta_articles CASCADE;
-            CREATE TABLE
-            dd_delta_articles(article_id text,
-                 text text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_people_mentions {
-            sql: """ DROP TABLE IF EXISTS dd_new_people_mentions CASCADE;
-            CREATE TABLE
-            dd_new_people_mentions(sentence_id text,
-                      start_position int,
-                      length int,
-                      text text,
-                      mention_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_has_spouse_features {
-            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse_features CASCADE;
-            CREATE TABLE
-            dd_delta_has_spouse_features(relation_id text,
-                            feature text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_articles {
-            sql: """ DROP TABLE IF EXISTS dd_new_articles CASCADE;
-            CREATE TABLE
-            dd_new_articles(article_id text,
-               text text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_has_spouse_candidates {
-            sql: """ DROP TABLE IF EXISTS dd_new_has_spouse_candidates CASCADE;
-            CREATE TABLE
-            dd_new_has_spouse_candidates(person1_id text,
-                            person2_id text,
-                            sentence_id text,
-                            description text,
-                            relation_id text,
-                            is_true boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_has_spouse_features {
-            sql: """ DROP TABLE IF EXISTS dd_new_has_spouse_features CASCADE;
-            CREATE TABLE
-            dd_new_has_spouse_features(relation_id text,
-                          feature text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_sentences {
-            sql: """ DROP TABLE IF EXISTS dd_new_sentences CASCADE;
-            CREATE TABLE
-            dd_new_sentences(document_id text,
-                sentence text,
-                words text[],
-                lemma text[],
-                pos_tags text[],
-                dependencies text[],
-                ner_tags text[],
-                sentence_offset int,
-                sentence_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_people_mentions {
-            sql: """ DROP TABLE IF EXISTS dd_delta_people_mentions CASCADE;
-            CREATE TABLE
-            dd_delta_people_mentions(sentence_id text,
-                        start_position int,
-                        length int,
-                        text text,
-                        mention_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_has_spouse_candidates {
-            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse_candidates CASCADE;
-            CREATE TABLE
-            dd_delta_has_spouse_candidates(person1_id text,
-                              person2_id text,
-                              sentence_id text,
-                              description text,
-                              relation_id text,
-                              is_true boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_sentences {
-            sql: """ DROP TABLE IF EXISTS dd_delta_sentences CASCADE;
-            CREATE TABLE
-            dd_delta_sentences(document_id text,
-                  sentence text,
-                  words text[],
-                  lemma text[],
-                  pos_tags text[],
-                  dependencies text[],
-                  ner_tags text[],
-                  sentence_offset int,
-                  sentence_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_has_spouse {
-            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse CASCADE;
-            CREATE TABLE
-            dd_delta_has_spouse(relation_id text,
-                   id bigint,
-                   label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE dd_delta_articles;
-          TRUNCATE dd_new_people_mentions;
-          TRUNCATE dd_delta_has_spouse_features;
-          TRUNCATE dd_new_articles;
-          TRUNCATE dd_new_has_spouse_candidates;
-          TRUNCATE dd_new_has_spouse_features;
-          TRUNCATE dd_new_sentences;
-          TRUNCATE dd_delta_people_mentions;
-          TRUNCATE dd_delta_has_spouse_candidates;
-          TRUNCATE dd_delta_sentences;
-          TRUNCATE dd_delta_has_spouse;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_dd_new_people_mentions {
         sql: """ TRUNCATE dd_new_people_mentions;
         INSERT INTO dd_new_people_mentions SELECT R0.sentence_id, R0.start_position, R0.length, R0.text, R0.mention_id
@@ -178,8 +33,13 @@ SELECT R0.sentence_id, R0.start_position, R0.length, R0.text, R0.mention_id
 FROM dd_delta_people_mentions R0
         
         """
+          output_relation: "dd_new_people_mentions"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_people_mentions_by_ext_people" ]
+          input_relations: [
+            people_mentions
+            dd_delta_people_mentions
+          ]
       }
     
 
@@ -193,8 +53,13 @@ SELECT R0.article_id, R0.text
 FROM dd_delta_articles R0
         
         """
+          output_relation: "dd_new_articles"
         style: "sql_extractor"
           
+          input_relations: [
+            articles
+            dd_delta_articles
+          ]
       }
     
 
@@ -208,8 +73,13 @@ SELECT R0.person1_id, R0.person2_id, R0.sentence_id, R0.description, R0.relation
 FROM dd_delta_has_spouse_candidates R0
         
         """
+          output_relation: "dd_new_has_spouse_candidates"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_has_spouse_candidates_by_ext_has_spouse" ]
+          input_relations: [
+            has_spouse_candidates
+            dd_delta_has_spouse_candidates
+          ]
       }
     
 
@@ -223,8 +93,13 @@ SELECT R0.relation_id, R0.feature
 FROM dd_delta_has_spouse_features R0
         
         """
+          output_relation: "dd_new_has_spouse_features"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_has_spouse_features_by_ext_has_spouse_features" ]
+          input_relations: [
+            has_spouse_features
+            dd_delta_has_spouse_features
+          ]
       }
     
 
@@ -238,8 +113,13 @@ SELECT R0.document_id, R0.sentence, R0.words, R0.lemma, R0.pos_tags, R0.dependen
 FROM dd_delta_sentences R0
         
         """
+          output_relation: "dd_new_sentences"
         style: "sql_extractor"
           
+          input_relations: [
+            sentences
+            dd_delta_sentences
+          ]
       }
     
 
@@ -250,8 +130,12 @@ FROM dd_delta_sentences R0
         
           
         """
+          output_relation: "dd_delta_has_spouse"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_has_spouse_candidates_by_ext_has_spouse" ]
+          input_relations: [
+            dd_delta_has_spouse_candidates
+          ]
       }
     
 
@@ -267,8 +151,13 @@ SELECT DISTINCT R0.relation_id, id, label
         
           
         """
+          output_relation: "dd_new_has_spouse"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_has_spouse" ]
+          input_relations: [
+            has_spouse
+            dd_delta_has_spouse
+          ]
       }
     
 
@@ -281,7 +170,10 @@ FROM dd_delta_sentences R0
           udf: ${APP_HOME}"/udf/ext_people.py"
           style: "tsv_extractor" 
           
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            dd_delta_sentences
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -299,7 +191,12 @@ FROM dd_new_people_mentions R0, dd_delta_people_mentions R1
           udf: ${APP_HOME}"/udf/ext_has_spouse.py"
           style: "tsv_extractor" 
           dependencies: [ "ext_dd_delta_people_mentions_by_ext_people" ,  "ext_dd_new_people_mentions" ]
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            dd_delta_people_mentions
+            people_mentions
+            dd_new_people_mentions
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -329,7 +226,18 @@ FROM dd_new_sentences R0, dd_new_has_spouse_candidates R1, dd_new_people_mention
           udf: ${APP_HOME}"/udf/ext_has_spouse_features.py"
           style: "tsv_extractor" 
           dependencies: [ "ext_dd_delta_has_spouse_candidates_by_ext_has_spouse" ,  "ext_dd_new_sentences" ,  "ext_dd_delta_people_mentions_by_ext_people" ,  "ext_dd_new_people_mentions" ,  "ext_dd_new_has_spouse_candidates" ]
-          input_batch_size: ${INPUT_BATCH_SIZE} 
+          input_relations: [
+            sentences
+            has_spouse_candidates
+            people_mentions
+            dd_delta_sentences
+            dd_new_sentences
+            dd_delta_has_spouse_candidates
+            dd_new_has_spouse_candidates
+            dd_delta_people_mentions
+            dd_new_people_mentions
+          ]
+          input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
       
@@ -344,23 +252,17 @@ FROM dd_new_sentences R0, dd_new_has_spouse_candidates R1, dd_new_people_mention
         WHERE R1.relation_id = R0.relation_id  AND R2.relation_id = R0.relation_id """
           function: "Imply(dd_new_has_spouse.R0.label)"
           weight: "?(dd_weight_column_0)"
+          dependencies: [ "ext_dd_delta_has_spouse_candidates_by_ext_has_spouse" ,  "ext_dd_new_has_spouse_candidates" ,  "ext_dd_delta_has_spouse_features_by_ext_has_spouse_features" ]
+          input_relations: [
+            dd_new_has_spouse
+            dd_delta_has_spouse_candidates
+            has_spouse_features
+            dd_new_has_spouse_candidates
+            dd_delta_has_spouse_features
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_dd_delta_articles
-  init_dd_new_people_mentions
-  init_dd_delta_has_spouse_features
-  init_dd_new_articles
-  init_dd_new_has_spouse_candidates
-  init_dd_new_has_spouse_features
-  init_dd_new_sentences
-  init_dd_delta_people_mentions
-  init_dd_delta_has_spouse_candidates
-  init_dd_delta_sentences
-  init_dd_delta_has_spouse
-  init_dd_new_has_spouse
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_dd_new_has_spouse_candidates
   ext_dd_delta_has_spouse_candidates_by_ext_has_spouse
@@ -388,8 +290,5 @@ deepdive.pipeline.pipelines.endtoend: [
   ext_dd_new_sentences
   ext_dd_new_articles
   dd_delta_inf_istrue_has_spouse
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]
 deepdive.pipeline.base_dir: ${BASEDIR}

--- a/test/expected-output-test/spouse_example_new_inference/compile-incremental.expected
+++ b/test/expected-output-test/spouse_example_new_inference/compile-incremental.expected
@@ -23,151 +23,6 @@ dd_new_has_spouse.label: Boolean
       }
     
 
-          deepdive.extraction.extractors.init_dd_delta_articles {
-            sql: """ DROP TABLE IF EXISTS dd_delta_articles CASCADE;
-            CREATE TABLE
-            dd_delta_articles(article_id text,
-                 text text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_people_mentions {
-            sql: """ DROP TABLE IF EXISTS dd_new_people_mentions CASCADE;
-            CREATE TABLE
-            dd_new_people_mentions(sentence_id text,
-                      start_position int,
-                      length int,
-                      text text,
-                      mention_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_has_spouse_features {
-            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse_features CASCADE;
-            CREATE TABLE
-            dd_delta_has_spouse_features(relation_id text,
-                            feature text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_articles {
-            sql: """ DROP TABLE IF EXISTS dd_new_articles CASCADE;
-            CREATE TABLE
-            dd_new_articles(article_id text,
-               text text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_has_spouse_candidates {
-            sql: """ DROP TABLE IF EXISTS dd_new_has_spouse_candidates CASCADE;
-            CREATE TABLE
-            dd_new_has_spouse_candidates(person1_id text,
-                            person2_id text,
-                            sentence_id text,
-                            description text,
-                            relation_id text,
-                            is_true boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_has_spouse_features {
-            sql: """ DROP TABLE IF EXISTS dd_new_has_spouse_features CASCADE;
-            CREATE TABLE
-            dd_new_has_spouse_features(relation_id text,
-                          feature text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_new_sentences {
-            sql: """ DROP TABLE IF EXISTS dd_new_sentences CASCADE;
-            CREATE TABLE
-            dd_new_sentences(document_id text,
-                sentence text,
-                words text[],
-                lemma text[],
-                pos_tags text[],
-                dependencies text[],
-                ner_tags text[],
-                sentence_offset int,
-                sentence_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_people_mentions {
-            sql: """ DROP TABLE IF EXISTS dd_delta_people_mentions CASCADE;
-            CREATE TABLE
-            dd_delta_people_mentions(sentence_id text,
-                        start_position int,
-                        length int,
-                        text text,
-                        mention_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_has_spouse_candidates {
-            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse_candidates CASCADE;
-            CREATE TABLE
-            dd_delta_has_spouse_candidates(person1_id text,
-                              person2_id text,
-                              sentence_id text,
-                              description text,
-                              relation_id text,
-                              is_true boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_sentences {
-            sql: """ DROP TABLE IF EXISTS dd_delta_sentences CASCADE;
-            CREATE TABLE
-            dd_delta_sentences(document_id text,
-                  sentence text,
-                  words text[],
-                  lemma text[],
-                  pos_tags text[],
-                  dependencies text[],
-                  ner_tags text[],
-                  sentence_offset int,
-                  sentence_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_dd_delta_has_spouse {
-            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse CASCADE;
-            CREATE TABLE
-            dd_delta_has_spouse(relation_id text,
-                   id bigint,
-                   label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE dd_delta_articles;
-          TRUNCATE dd_new_people_mentions;
-          TRUNCATE dd_delta_has_spouse_features;
-          TRUNCATE dd_new_articles;
-          TRUNCATE dd_new_has_spouse_candidates;
-          TRUNCATE dd_new_has_spouse_features;
-          TRUNCATE dd_new_sentences;
-          TRUNCATE dd_delta_people_mentions;
-          TRUNCATE dd_delta_has_spouse_candidates;
-          TRUNCATE dd_delta_sentences;
-          TRUNCATE dd_delta_has_spouse;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_dd_new_people_mentions {
         sql: """ TRUNCATE dd_new_people_mentions;
         INSERT INTO dd_new_people_mentions SELECT R0.sentence_id, R0.start_position, R0.length, R0.text, R0.mention_id
@@ -178,8 +33,13 @@ SELECT R0.sentence_id, R0.start_position, R0.length, R0.text, R0.mention_id
 FROM dd_delta_people_mentions R0
         
         """
+          output_relation: "dd_new_people_mentions"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_people_mentions_by_ext_people" ]
+          input_relations: [
+            people_mentions
+            dd_delta_people_mentions
+          ]
       }
     
 
@@ -193,8 +53,13 @@ SELECT R0.article_id, R0.text
 FROM dd_delta_articles R0
         
         """
+          output_relation: "dd_new_articles"
         style: "sql_extractor"
           
+          input_relations: [
+            articles
+            dd_delta_articles
+          ]
       }
     
 
@@ -208,8 +73,13 @@ SELECT R0.person1_id, R0.person2_id, R0.sentence_id, R0.description, R0.relation
 FROM dd_delta_has_spouse_candidates R0
         
         """
+          output_relation: "dd_new_has_spouse_candidates"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_has_spouse_candidates_by_ext_has_spouse" ]
+          input_relations: [
+            has_spouse_candidates
+            dd_delta_has_spouse_candidates
+          ]
       }
     
 
@@ -223,8 +93,13 @@ SELECT R0.relation_id, R0.feature
 FROM dd_delta_has_spouse_features R0
         
         """
+          output_relation: "dd_new_has_spouse_features"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_has_spouse_features_by_ext_has_spouse_features" ]
+          input_relations: [
+            has_spouse_features
+            dd_delta_has_spouse_features
+          ]
       }
     
 
@@ -238,8 +113,13 @@ SELECT R0.document_id, R0.sentence, R0.words, R0.lemma, R0.pos_tags, R0.dependen
 FROM dd_delta_sentences R0
         
         """
+          output_relation: "dd_new_sentences"
         style: "sql_extractor"
           
+          input_relations: [
+            sentences
+            dd_delta_sentences
+          ]
       }
     
 
@@ -250,8 +130,12 @@ FROM dd_delta_sentences R0
         
           
         """
+          output_relation: "dd_delta_has_spouse"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_has_spouse_candidates_by_ext_has_spouse" ]
+          input_relations: [
+            dd_delta_has_spouse_candidates
+          ]
       }
     
 
@@ -267,8 +151,13 @@ SELECT DISTINCT R0.relation_id, id, label
         
           
         """
+          output_relation: "dd_new_has_spouse"
         style: "sql_extractor"
           dependencies: [ "ext_dd_delta_has_spouse" ]
+          input_relations: [
+            has_spouse
+            dd_delta_has_spouse
+          ]
       }
     
 
@@ -281,6 +170,9 @@ FROM dd_delta_sentences R0
           udf: ${APP_HOME}"/udf/ext_people.py"
           style: "tsv_extractor" 
           
+          input_relations: [
+            dd_delta_sentences
+          ]
           input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
@@ -299,6 +191,11 @@ FROM dd_new_people_mentions R0, dd_delta_people_mentions R1
           udf: ${APP_HOME}"/udf/ext_has_spouse.py"
           style: "tsv_extractor" 
           dependencies: [ "ext_dd_delta_people_mentions_by_ext_people" ,  "ext_dd_new_people_mentions" ]
+          input_relations: [
+            dd_delta_people_mentions
+            people_mentions
+            dd_new_people_mentions
+          ]
           input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
@@ -325,6 +222,16 @@ FROM dd_new_sentences R0, dd_new_has_spouse_candidates R1, dd_new_people_mention
           udf: ${APP_HOME}"/udf/ext_has_spouse_features.py"
           style: "tsv_extractor" 
           dependencies: [ "ext_dd_delta_has_spouse_candidates_by_ext_has_spouse" ,  "ext_dd_new_sentences" ,  "ext_dd_delta_people_mentions_by_ext_people" ,  "ext_dd_new_people_mentions" ,  "ext_dd_new_has_spouse_candidates" ]
+          input_relations: [
+            dd_delta_sentences
+            has_spouse_candidates
+            people_mentions
+            dd_new_sentences
+            dd_delta_has_spouse_candidates
+            dd_new_has_spouse_candidates
+            dd_delta_people_mentions
+            dd_new_people_mentions
+          ]
           input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
@@ -340,6 +247,14 @@ FROM dd_new_sentences R0, dd_new_has_spouse_candidates R1, dd_new_people_mention
         WHERE R1.relation_id = R0.relation_id  AND R2.relation_id = R0.relation_id """
           function: "Imply(dd_new_has_spouse.R0.label)"
           weight: "?(dd_weight_column_0)"
+          dependencies: [ "ext_dd_delta_has_spouse_candidates_by_ext_has_spouse" ,  "ext_dd_new_has_spouse_candidates" ,  "ext_dd_delta_has_spouse_features_by_ext_has_spouse_features" ]
+          input_relations: [
+            dd_new_has_spouse
+            dd_delta_has_spouse_candidates
+            has_spouse_features
+            dd_new_has_spouse_candidates
+            dd_delta_has_spouse_features
+          ]
         }
       
 
@@ -350,23 +265,14 @@ FROM dd_new_sentences R0, dd_new_has_spouse_candidates R1, dd_new_people_mention
         WHERE R2.relation_id = R1.relation_id  AND R3.person1_id = R2.person2_id  AND R3.person2_id = R2.person1_id  AND R3.relation_id = R0.relation_id """
           function: "Equal(dd_new_has_spouse.R0.label, dd_new_has_spouse.R1.label)"
           weight: "3.0"
+          dependencies: [ "ext_dd_new_has_spouse_candidates" ]
+          input_relations: [
+            dd_new_has_spouse
+            dd_new_has_spouse_candidates
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_dd_delta_articles
-  init_dd_new_people_mentions
-  init_dd_delta_has_spouse_features
-  init_dd_new_articles
-  init_dd_new_has_spouse_candidates
-  init_dd_new_has_spouse_features
-  init_dd_new_sentences
-  init_dd_delta_people_mentions
-  init_dd_delta_has_spouse_candidates
-  init_dd_delta_sentences
-  init_dd_delta_has_spouse
-  init_dd_new_has_spouse
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_dd_new_has_spouse_candidates
   ext_dd_delta_has_spouse_candidates_by_ext_has_spouse
@@ -396,8 +302,5 @@ deepdive.pipeline.pipelines.endtoend: [
   ext_dd_new_articles
   dd_delta_inf_istrue_has_spouse
   dd_delta_inf_equal_has_spouse_has_spouse
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]
 deepdive.pipeline.base_dir: ${BASEDIR}

--- a/test/expected-output-test/spouse_example_new_inference/compile-incremental.expected
+++ b/test/expected-output-test/spouse_example_new_inference/compile-incremental.expected
@@ -23,6 +23,151 @@ dd_new_has_spouse.label: Boolean
       }
     
 
+          deepdive.extraction.extractors.init_dd_delta_articles {
+            sql: """ DROP TABLE IF EXISTS dd_delta_articles CASCADE;
+            CREATE TABLE
+            dd_delta_articles(article_id text,
+                 text text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_people_mentions {
+            sql: """ DROP TABLE IF EXISTS dd_new_people_mentions CASCADE;
+            CREATE TABLE
+            dd_new_people_mentions(sentence_id text,
+                      start_position int,
+                      length int,
+                      text text,
+                      mention_id text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_has_spouse_features {
+            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse_features CASCADE;
+            CREATE TABLE
+            dd_delta_has_spouse_features(relation_id text,
+                            feature text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_articles {
+            sql: """ DROP TABLE IF EXISTS dd_new_articles CASCADE;
+            CREATE TABLE
+            dd_new_articles(article_id text,
+               text text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_has_spouse_candidates {
+            sql: """ DROP TABLE IF EXISTS dd_new_has_spouse_candidates CASCADE;
+            CREATE TABLE
+            dd_new_has_spouse_candidates(person1_id text,
+                            person2_id text,
+                            sentence_id text,
+                            description text,
+                            relation_id text,
+                            is_true boolean)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_has_spouse_features {
+            sql: """ DROP TABLE IF EXISTS dd_new_has_spouse_features CASCADE;
+            CREATE TABLE
+            dd_new_has_spouse_features(relation_id text,
+                          feature text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_new_sentences {
+            sql: """ DROP TABLE IF EXISTS dd_new_sentences CASCADE;
+            CREATE TABLE
+            dd_new_sentences(document_id text,
+                sentence text,
+                words text[],
+                lemma text[],
+                pos_tags text[],
+                dependencies text[],
+                ner_tags text[],
+                sentence_offset int,
+                sentence_id text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_people_mentions {
+            sql: """ DROP TABLE IF EXISTS dd_delta_people_mentions CASCADE;
+            CREATE TABLE
+            dd_delta_people_mentions(sentence_id text,
+                        start_position int,
+                        length int,
+                        text text,
+                        mention_id text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_has_spouse_candidates {
+            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse_candidates CASCADE;
+            CREATE TABLE
+            dd_delta_has_spouse_candidates(person1_id text,
+                              person2_id text,
+                              sentence_id text,
+                              description text,
+                              relation_id text,
+                              is_true boolean)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_sentences {
+            sql: """ DROP TABLE IF EXISTS dd_delta_sentences CASCADE;
+            CREATE TABLE
+            dd_delta_sentences(document_id text,
+                  sentence text,
+                  words text[],
+                  lemma text[],
+                  pos_tags text[],
+                  dependencies text[],
+                  ner_tags text[],
+                  sentence_offset int,
+                  sentence_id text)
+            """
+            style: "sql_extractor"
+          }
+
+          deepdive.extraction.extractors.init_dd_delta_has_spouse {
+            sql: """ DROP TABLE IF EXISTS dd_delta_has_spouse CASCADE;
+            CREATE TABLE
+            dd_delta_has_spouse(relation_id text,
+                   id bigint,
+                   label boolean)
+            """
+            style: "sql_extractor"
+          }
+
+        deepdive.extraction.extractors.cleanup {
+          sql: """
+          TRUNCATE dd_delta_articles;
+          TRUNCATE dd_new_people_mentions;
+          TRUNCATE dd_delta_has_spouse_features;
+          TRUNCATE dd_new_articles;
+          TRUNCATE dd_new_has_spouse_candidates;
+          TRUNCATE dd_new_has_spouse_features;
+          TRUNCATE dd_new_sentences;
+          TRUNCATE dd_delta_people_mentions;
+          TRUNCATE dd_delta_has_spouse_candidates;
+          TRUNCATE dd_delta_sentences;
+          TRUNCATE dd_delta_has_spouse;
+          """
+          style: "sql_extractor"
+        }
+
       deepdive.extraction.extractors.ext_dd_new_people_mentions {
         sql: """ TRUNCATE dd_new_people_mentions;
         INSERT INTO dd_new_people_mentions SELECT R0.sentence_id, R0.start_position, R0.length, R0.text, R0.mention_id
@@ -304,3 +449,20 @@ deepdive.pipeline.pipelines.endtoend: [
   dd_delta_inf_equal_has_spouse_has_spouse
 ]
 deepdive.pipeline.base_dir: ${BASEDIR}
+deepdive.pipeline.pipelines.initdb: [
+  init_dd_delta_articles
+  init_dd_new_people_mentions
+  init_dd_delta_has_spouse_features
+  init_dd_new_articles
+  init_dd_new_has_spouse_candidates
+  init_dd_new_has_spouse_features
+  init_dd_new_sentences
+  init_dd_delta_people_mentions
+  init_dd_delta_has_spouse_candidates
+  init_dd_delta_sentences
+  init_dd_delta_has_spouse
+  init_dd_new_has_spouse
+]
+deepdive.pipeline.pipelines.cleanup: [
+  cleanup
+]

--- a/test/expected-output-test/spouse_example_new_inference/compile.expected
+++ b/test/expected-output-test/spouse_example_new_inference/compile.expected
@@ -17,87 +17,6 @@
       }
     
 
-          deepdive.extraction.extractors.init_sentences {
-            sql: """ DROP TABLE IF EXISTS sentences CASCADE;
-            CREATE TABLE
-            sentences(document_id text,
-         sentence text,
-         words text[],
-         lemma text[],
-         pos_tags text[],
-         dependencies text[],
-         ner_tags text[],
-         sentence_offset int,
-         sentence_id text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_has_spouse_candidates {
-            sql: """ DROP TABLE IF EXISTS has_spouse_candidates CASCADE;
-            CREATE TABLE
-            has_spouse_candidates(person1_id text,
-                     person2_id text,
-                     sentence_id text,
-                     description text,
-                     relation_id text,
-                     is_true boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_has_spouse {
-            sql: """ DROP TABLE IF EXISTS has_spouse CASCADE;
-            CREATE TABLE
-            has_spouse(relation_id text,
-          id bigint,
-          label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_articles {
-            sql: """ DROP TABLE IF EXISTS articles CASCADE;
-            CREATE TABLE
-            articles(article_id text,
-        text text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_has_spouse_features {
-            sql: """ DROP TABLE IF EXISTS has_spouse_features CASCADE;
-            CREATE TABLE
-            has_spouse_features(relation_id text,
-                   feature text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_people_mentions {
-            sql: """ DROP TABLE IF EXISTS people_mentions CASCADE;
-            CREATE TABLE
-            people_mentions(sentence_id text,
-               start_position int,
-               length int,
-               text text,
-               mention_id text)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE sentences;
-          TRUNCATE has_spouse_candidates;
-          TRUNCATE has_spouse;
-          TRUNCATE articles;
-          TRUNCATE has_spouse_features;
-          TRUNCATE people_mentions;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_has_spouse {
         sql: """ 
         INSERT INTO has_spouse SELECT DISTINCT R0.relation_id, 0 AS id, R0.is_true AS label
@@ -105,8 +24,12 @@
         
           
         """
+          output_relation: "has_spouse"
         style: "sql_extractor"
           dependencies: [ "ext_has_spouse_candidates_by_ext_has_spouse" ]
+          input_relations: [
+            has_spouse_candidates
+          ]
       }
     
 
@@ -119,6 +42,9 @@ FROM sentences R0
           udf: ${APP_HOME}"/udf/ext_people.py"
           style: "tsv_extractor" 
           
+          input_relations: [
+            sentences
+          ]
           input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
@@ -133,6 +59,9 @@ FROM people_mentions R0, people_mentions R1
           udf: ${APP_HOME}"/udf/ext_has_spouse.py"
           style: "tsv_extractor" 
           dependencies: [ "ext_people_mentions_by_ext_people" ]
+          input_relations: [
+            people_mentions
+          ]
           input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
@@ -147,6 +76,11 @@ FROM sentences R0, has_spouse_candidates R1, people_mentions R2, people_mentions
           udf: ${APP_HOME}"/udf/ext_has_spouse_features.py"
           style: "tsv_extractor" 
           dependencies: [ "ext_has_spouse_candidates_by_ext_has_spouse" ,  "ext_people_mentions_by_ext_people" ]
+          input_relations: [
+            sentences
+            has_spouse_candidates
+            people_mentions
+          ]
           input_batch_size: ${INPUT_BATCH_SIZE}
           parallelism: ${PARALLELISM}
         }
@@ -159,6 +93,12 @@ FROM sentences R0, has_spouse_candidates R1, people_mentions R2, people_mentions
         WHERE R1.relation_id = R0.relation_id  AND R2.relation_id = R0.relation_id """
           function: "Imply(has_spouse.R0.label)"
           weight: "?(dd_weight_column_0)"
+          dependencies: [ "ext_has_spouse_candidates_by_ext_has_spouse" ,  "ext_has_spouse_features_by_ext_has_spouse_features" ]
+          input_relations: [
+            has_spouse
+            has_spouse_candidates
+            has_spouse_features
+          ]
         }
       
 
@@ -169,17 +109,14 @@ FROM sentences R0, has_spouse_candidates R1, people_mentions R2, people_mentions
         WHERE R2.relation_id = R1.relation_id  AND R3.person1_id = R2.person2_id  AND R3.person2_id = R2.person1_id  AND R3.relation_id = R0.relation_id """
           function: "Equal(has_spouse.R0.label, has_spouse.R1.label)"
           weight: "3.0"
+          dependencies: [ "ext_has_spouse_candidates_by_ext_has_spouse" ]
+          input_relations: [
+            has_spouse
+            has_spouse_candidates
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_sentences
-  init_has_spouse_candidates
-  init_has_spouse
-  init_articles
-  init_has_spouse_features
-  init_people_mentions
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_has_spouse
   ext_people_mentions_by_ext_people
@@ -197,7 +134,4 @@ deepdive.pipeline.pipelines.endtoend: [
   ext_has_spouse_features_by_ext_has_spouse_features
   inf_istrue_has_spouse
   inf_equal_has_spouse_has_spouse
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]

--- a/test/expected-output-test/views/compile.expected
+++ b/test/expected-output-test/views/compile.expected
@@ -17,30 +17,18 @@
       }
     
 
-          deepdive.extraction.extractors.init_R {
-            sql: """ DROP TABLE IF EXISTS R CASCADE;
-            CREATE TABLE
-            R(a int,
- b int)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE R;
-          """
-          style: "sql_extractor"
-        }
-
       deepdive.extraction.extractors.ext_A {
         sql: """ DROP VIEW IF EXISTS A;
         CREATE VIEW A AS SELECT R0.a AS column_0, (R0.a + R0.b) AS column_1
 FROM R R0
         
         """
+          output_relation: "A"
         style: "sql_extractor"
           
+          input_relations: [
+            R
+          ]
       }
     
 
@@ -50,14 +38,16 @@ FROM R R0
 FROM A R0, R R1
         WHERE R1.a = R0.column_1 
         """
+          output_relation: "B"
         style: "sql_extractor"
           dependencies: [ "ext_A" ]
+          input_relations: [
+            A
+            R
+          ]
       }
     
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_R
-]
 deepdive.pipeline.pipelines.extraction: [
   ext_A
   ext_B
@@ -65,7 +55,4 @@ deepdive.pipeline.pipelines.extraction: [
 deepdive.pipeline.pipelines.endtoend: [
   ext_A
   ext_B
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]

--- a/test/expected-output-test/weights/compile.expected
+++ b/test/expected-output-test/weights/compile.expected
@@ -21,78 +21,6 @@ c.label: Boolean
       }
     
 
-          deepdive.extraction.extractors.init_e {
-            sql: """ DROP TABLE IF EXISTS e CASCADE;
-            CREATE TABLE
-            e(k int,
- id bigint,
- label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_f {
-            sql: """ DROP TABLE IF EXISTS f CASCADE;
-            CREATE TABLE
-            f(k int,
- id bigint,
- label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_a {
-            sql: """ DROP TABLE IF EXISTS a CASCADE;
-            CREATE TABLE
-            a(k int,
- id bigint,
- label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_b {
-            sql: """ DROP TABLE IF EXISTS b CASCADE;
-            CREATE TABLE
-            b(k int,
- p int,
- q text)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_c {
-            sql: """ DROP TABLE IF EXISTS c CASCADE;
-            CREATE TABLE
-            c(k int,
- id bigint,
- label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-          deepdive.extraction.extractors.init_d {
-            sql: """ DROP TABLE IF EXISTS d CASCADE;
-            CREATE TABLE
-            d(k int,
- id bigint,
- label boolean)
-            """
-            style: "sql_extractor"
-          }
-
-        deepdive.extraction.extractors.cleanup {
-          sql: """
-          TRUNCATE e;
-          TRUNCATE f;
-          TRUNCATE a;
-          TRUNCATE b;
-          TRUNCATE c;
-          TRUNCATE d;
-          """
-          style: "sql_extractor"
-        }
-
         deepdive.inference.factors.inf_istrue_a {
           input_query: """
           SELECT R0.id AS "a.R0.id" , (R0.k + R1.p) AS "dd_weight_column_0" 
@@ -100,6 +28,11 @@ c.label: Boolean
         WHERE R1.k = R0.k """
           function: "Imply(a.R0.label)"
           weight: "?(dd_weight_column_0)"
+          
+          input_relations: [
+            a
+            b
+          ]
         }
       
 
@@ -110,6 +43,11 @@ c.label: Boolean
         WHERE R1.k = R0.k """
           function: "Imply(c.R0.label)"
           weight: "?"
+          
+          input_relations: [
+            c
+            b
+          ]
         }
       
 
@@ -120,6 +58,11 @@ c.label: Boolean
         WHERE R1.k = R0.k """
           function: "Imply(d.R0.label)"
           weight: "?(dd_weight_column_0, dd_weight_column_1)"
+          
+          input_relations: [
+            d
+            b
+          ]
         }
       
 
@@ -130,6 +73,11 @@ c.label: Boolean
         WHERE R1.k = R0.k """
           function: "Imply(e.R0.label)"
           weight: "-10"
+          
+          input_relations: [
+            e
+            b
+          ]
         }
       
 
@@ -140,17 +88,14 @@ c.label: Boolean
         WHERE R1.k = R0.k """
           function: "Imply(f.R0.label)"
           weight: "-0.3"
+          
+          input_relations: [
+            f
+            b
+          ]
         }
       
 deepdive.pipeline.run: ${PIPELINE}
-deepdive.pipeline.pipelines.initdb: [
-  init_e
-  init_f
-  init_a
-  init_b
-  init_c
-  init_d
-]
 deepdive.pipeline.pipelines.inference: [
   inf_istrue_a
   inf_istrue_c
@@ -164,7 +109,4 @@ deepdive.pipeline.pipelines.endtoend: [
   inf_istrue_d
   inf_istrue_e
   inf_istrue_f
-]
-deepdive.pipeline.pipelines.cleanup: [
-  cleanup
 ]


### PR DESCRIPTION
- Fixes a bug not producing the correct dependencies for relations referred from a quantified body, e.g., in `EXISTS[ ... ]`.
- Also adds `input_relations` and `output_relation` to extractors and factors for DeepDive's new data flow compiler.
- `initdb` and `cleanup` pipelines and extractors are removed in favor of schema.json based DeepDive commands, e.g., `deepdive-initdb` and `deepdive-load`.

@ThomasPalomares Feel free to comment on the code as well.
