### PR TITLE
Makes sure schema entries are exported for rules that compile into views

### DIFF
--- a/test/expected-output-test/views/export-schema.expected
+++ b/test/expected-output-test/views/export-schema.expected
@@ -1,0 +1,1 @@
+{"relations" : {"R" : {"columns" : {"a" : {"type" : "int", "index" : 0}, "b" : {"type" : "int", "index" : 1}}}, "A" : {"type" : "view", "columns" : {"column_0" : {"type" : "UNKNOWN", "index" : 0}, "column_1" : {"type" : "UNKNOWN", "index" : 1}}}, "B" : {"type" : "view", "columns" : {"column_0" : {"type" : "UNKNOWN", "index" : 0}, "column_1" : {"type" : "UNKNOWN", "index" : 1}}}}}


### PR DESCRIPTION
with `type: view` relation and UNKNOWN type columns whose names are
`column_i` for i = 0 to N-1.

Fixes #69
