### PR TITLE
Fixes redundant columns compiled for join variables in queries

### DIFF
--- a/src/main/scala/org/deepdive/ddlog/DeepDiveLogParser.scala
+++ b/src/main/scala/org/deepdive/ddlog/DeepDiveLogParser.scala
@@ -436,8 +436,9 @@ class DeepDiveLogParser extends JavaTokenParsers {
         val (headTerms, headTermAnnos) = headTermsZippedWithAnnotations unzip
         val headTermsToUse =
           if (headTerms nonEmpty) headTerms else {
-            val definedVars = cq.bodies map {_ flatMap DeepDiveLogSemanticChecker.collectDefinedVars} reduce {_ intersect _}
-            definedVars map VarExpr
+            val definedVarsByBodies = cq.bodies map { _ flatMap DeepDiveLogSemanticChecker.collectDefinedVars }
+            val definedVarsCommon = definedVarsByBodies reduce {_ intersect _}
+            definedVarsCommon.toSet.toList map VarExpr
           }
         cq.copy(
           headTerms = headTermsToUse,

--- a/test/query-test/spouse_example/repeated-vars.ddlogq
+++ b/test/query-test/spouse_example/repeated-vars.ddlogq
@@ -1,0 +1,1 @@
+?- articles(id1, content), articles(id2, content).

--- a/test/query-test/spouse_example/repeated-vars.ddlogq.expected
+++ b/test/query-test/spouse_example/repeated-vars.ddlogq.expected
@@ -1,0 +1,3 @@
+SELECT R0.article_id AS "id1", R0.text AS "content", R1.article_id AS "id2"
+FROM articles R0, articles R1
+        WHERE R1.text = R0.text 


### PR DESCRIPTION
```
?- articles(id1, content), articles(id2, content).
```

It was producing an extra column for every join variable like:

```
SELECT R0.article_id AS "id1", R0.text AS "content", R1.article_id AS "id2", R0.text AS "content"
FROM articles R0, articles R1
        WHERE R1.text = R0.text 
```
