### PR TITLE
Add supervision truthiness and syntax

### DIFF
--- a/src/main/scala/org/deepdive/ddlog/DeepDiveLogCompiler.scala
+++ b/src/main/scala/org/deepdive/ddlog/DeepDiveLogCompiler.scala
@@ -466,9 +466,9 @@ class QueryCompiler(cq : ConjunctiveQuery, hackFrom: List[String] = Nil, hackWhe
 
     compileExtractorBlock(stmt, stmts, stmt.headName,
       stmts map { case stmt => stmt.q.copy(
-        headTerms = stmt.q.headTerms :+ stmt.supervision,
+        headTerms = stmt.q.headTerms :+ stmt.supervision :+ (stmt.truthiness.getOrElse(DoubleConst(1))),
         headTermAliases = {
-          stmt.q.headTermAliases orElse { Some(stmt.q.headTerms map (_ => None)) } map { _ :+ Some(deepdiveVariableLabelColumn) }
+          stmt.q.headTermAliases orElse { Some(stmt.q.headTerms map (_ => None)) } map { _ ::: List(Some(deepdiveVariableLabelColumn), Some(deepdiveVariableLabelTruthinessColumn)) }
         },
         isDistinct = false // XXX no need to take DISTINCT here since DeepDive will have to do it anyway
       ) }
@@ -684,6 +684,7 @@ object DeepDiveLogCompiler extends DeepDiveLogHandler {
   val deepdiveWeightColumnPrefix = "dd_weight_column_"
   val deepdiveVariableIdColumn = "dd_id"
   val deepdiveVariableLabelColumn = "dd_label"
+  val deepdiveVariableLabelTruthinessColumn = "dd_truthiness"
   val deepdivePrefixForVariablesIdsTable = "dd_variables_"
 
   // entry point for compilation

--- a/test/expected-output-test/chunking_example/compile.expected
+++ b/test/expected-output-test/chunking_example/compile.expected
@@ -13,10 +13,11 @@ sql: """
 SELECT R0.sent_id AS column_0
      , R0.word_id AS column_1
      , R1.tag AS column_2
-     ,
+     , 
 CASE WHEN R1.tag = R0.tag THEN true
      ELSE NULL
 END AS column_3
+     , 1.0 AS column_4
 FROM words R0
    , tags R1
 """
@@ -37,7 +38,7 @@ SELECT R0.sent_id AS column_0
      , R0.word AS column_2
      , R0.pos AS column_3
      , R0.true_tag AS column_4
-     ,
+     , 
 CASE WHEN R0.true_tag = 'B-UCP' THEN NULL
      WHEN R0.true_tag = 'I-UCP' THEN NULL
      WHEN strpos(R0.true_tag, '-') > 0 THEN split_part(R0.true_tag, '-', 2)
@@ -119,7 +120,7 @@ function: """AndCategorical(chunk.R0.dd_label)"""
 deepdive.inference.factors.linear_chain {
 weight: """?(dd_weight_column_0, dd_weight_column_1)"""
 non_category_weight_cols: [
-
+  
 ]
 input_query: """
 SELECT dd_id_0.dd_id AS "chunk.R0.dd_id"
@@ -166,7 +167,7 @@ function: """AndCategorical(chunk.R0.dd_label, chunk.R1.dd_label)"""
 deepdive.inference.factors.phony_rule {
 weight: """?(dd_weight_column_0, dd_weight_column_1)"""
 non_category_weight_cols: [
-
+  
 ]
 input_query: """
 SELECT dd_id_0.dd_id AS "chunk.R0.dd_id"

--- a/test/expected-output-test/if-then-else/compile.expected
+++ b/test/expected-output-test/if-then-else/compile.expected
@@ -13,6 +13,7 @@ CASE WHEN R0.l > 0 THEN true
      WHEN R0.l < 0 THEN false
      ELSE NULL
 END AS column_1
+     , 1.0 AS column_2
 FROM labels_resolved R0
 """
 input_relations: [

--- a/test/expected-output-test/materialize_annotation/compile.expected
+++ b/test/expected-output-test/materialize_annotation/compile.expected
@@ -24,6 +24,7 @@ deepdive.extraction.extractors.ext_VQ {
 sql: """
 SELECT R0.x AS column_0
      , true AS column_1
+     , 1.0 AS column_2
 FROM D R0
 """
 input_relations: [
@@ -56,6 +57,7 @@ SELECT R0.x AS column_0
 CASE WHEN length(R0.x) > 5 THEN true
      ELSE NULL
 END AS column_1
+     , 1.0 AS column_2
 FROM D R0
 """
 input_relations: [

--- a/test/expected-output-test/ocr_example/compile.expected
+++ b/test/expected-output-test/ocr_example/compile.expected
@@ -10,6 +10,7 @@ deepdive.extraction.extractors.ext_q1 {
 sql: """
 SELECT R0.wid AS column_0
      , R0.val AS column_1
+     , 1.0 AS column_2
 FROM label1 R0
 """
 input_relations: [
@@ -25,6 +26,7 @@ deepdive.extraction.extractors.ext_q2 {
 sql: """
 SELECT R0.wid AS column_0
      , R0.val AS column_1
+     , 1.0 AS column_2
 FROM label2 R0
 """
 input_relations: [

--- a/test/expected-output-test/smoke_example/compile.expected
+++ b/test/expected-output-test/smoke_example/compile.expected
@@ -10,6 +10,7 @@ deepdive.extraction.extractors.ext_smoke {
 sql: """
 SELECT R0.person_id AS column_0
      , R0.smokes AS column_1
+     , 1.0 AS column_2
 FROM person_smokes R0
 """
 input_relations: [
@@ -25,6 +26,7 @@ deepdive.extraction.extractors.ext_cancer {
 sql: """
 SELECT R0.person_id AS column_0
      , R0.has_cancer AS column_1
+     , 1.0 AS column_2
 FROM person_has_cancer R0
 """
 input_relations: [
@@ -39,7 +41,7 @@ materialize: false
 deepdive.inference.factors.inf_imply_smoke_cancer {
 weight: """0.5"""
 non_category_weight_cols: [
-
+  
 ]
 input_query: """
 SELECT dd_id_0.dd_id AS "smoke.R0.dd_id"
@@ -69,7 +71,7 @@ function: """Imply(smoke.R0.dd_label, cancer.R1.dd_label)"""
 deepdive.inference.factors.inf_imply_smoke_smoke {
 weight: """0.4"""
 non_category_weight_cols: [
-
+  
 ]
 input_query: """
 SELECT dd_id_0.dd_id AS "smoke.R0.dd_id"

--- a/test/expected-output-test/spouse_example/compile.expected
+++ b/test/expected-output-test/spouse_example/compile.expected
@@ -80,6 +80,7 @@ deepdive.extraction.extractors.ext_has_spouse {
 sql: """
 SELECT R0.relation_id AS column_0
      , R0.is_true AS column_1
+     , 1.0 AS column_2
 FROM has_spouse_candidates R0
 """
 input_relations: [


### PR DESCRIPTION
Now each var table has an extra column `dd_truthiness` and one can specify it in the supervision rule:

```
chunk(s, word, tag) = TRUE @ confidence :-
  words(s, word, _, pos),
  super(s, word, tag, confidence).
```
