### PR TITLE
Simplify grounding by removing joins with var ID tables

### DIFF
--- a/src/main/scala/org/deepdive/ddlog/DeepDiveLogCompiler.scala
+++ b/src/main/scala/org/deepdive/ddlog/DeepDiveLogCompiler.scala
@@ -116,7 +116,7 @@ class DeepDiveLogCompiler( program : DeepDiveLog.Program, config : DeepDiveLog.C
   // odd has happened.
   def resolveName( v : Variable ) : String = {
     v match { case Variable(v,relName,i) =>
-      val realRel = relName.replaceAll("^" + deepdivePrefixForVariablesWithIdsTable, "")
+      val realRel = relName.stripPrefix(deepdivePrefixForVariablesWithIdsTable)
       if(attrNameForRelationAndPosition contains (realRel,i)) {
         attrNameForRelationAndPosition(realRel,i)
       } else {
@@ -545,7 +545,6 @@ class QueryCompiler(cq : ConjunctiveQuery, hackFrom: List[String] = Nil, hackWhe
         val fakeBody        = headAsBodyWithIds ++ cqBody
         val fakeCQ          = stmt.q.copy(bodies = List(fakeBody))
 
-        // TODO XXX: Fix the `internal` hack below
         val qc = new QueryCompiler(fakeCQ)
 
         // weight columns
@@ -673,7 +672,7 @@ object DeepDiveLogCompiler extends DeepDiveLogHandler {
   val deepdiveVariableIdColumn = "dd_id"
   val deepdiveVariableLabelColumn = "dd_label"
   val deepdiveVariableLabelTruthinessColumn = "dd_truthiness"
-  val deepdivePrefixForVariablesWithIdsTable = "dd_predicate_"
+  val deepdivePrefixForVariablesWithIdsTable = "dd_variables_with_id_"
 
   // entry point for compilation
   override def run(parsedProgram: DeepDiveLog.Program, config: DeepDiveLog.Config) = {

--- a/src/main/scala/org/deepdive/ddlog/DeepDiveLogCompiler.scala
+++ b/src/main/scala/org/deepdive/ddlog/DeepDiveLogCompiler.scala
@@ -116,8 +116,9 @@ class DeepDiveLogCompiler( program : DeepDiveLog.Program, config : DeepDiveLog.C
   // odd has happened.
   def resolveName( v : Variable ) : String = {
     v match { case Variable(v,relName,i) =>
-      if(attrNameForRelationAndPosition contains (relName,i)) {
-        attrNameForRelationAndPosition(relName,i)
+      val realRel = relName.replaceAll("^" + deepdivePrefixForVariablesWithIdsTable, "")
+      if(attrNameForRelationAndPosition contains (realRel,i)) {
+        attrNameForRelationAndPosition(realRel,i)
       } else {
         // for views, columns names are in the form of "column_index"
         return s"column_${i}"
@@ -511,7 +512,7 @@ class QueryCompiler(cq : ConjunctiveQuery, hackFrom: List[String] = Nil, hackWhe
       case (x: Atom, i) if schemaDeclarationByRelationName get x.name exists (_.isQuery) =>
         // TODO maybe TableAlias can be useful here or we can completely get rid of it?
         // variable id column
-        s"""${deepdiveVariableIdColumn}_${headAsBody indexOf x}.${
+        s"""R${headAsBody indexOf x}.${
           deepdiveVariableIdColumn
         } AS "${x.name}.R${headAsBody indexOf x}.${deepdiveVariableIdColumn}\"""" :: (
           // project variable key columns as well (to reduce unnecssary joins)
@@ -530,22 +531,9 @@ class QueryCompiler(cq : ConjunctiveQuery, hackFrom: List[String] = Nil, hackWhe
       case _ => List.empty
     }
 
-    val internalVarTables = headAsBody.zipWithIndex flatMap {
-      case (x: Atom, i) if schemaDeclarationByRelationName get x.name exists (_.isQuery) =>
-        List(s"""${deepdivePrefixForVariablesIdsTable}${x.name} AS ${deepdiveVariableIdColumn}_${headAsBody indexOf x}""")
-      case _ => List.empty
+    val headAsBodyWithIds = headAsBody map {
+      case(x: Atom) => Atom(s"""${deepdivePrefixForVariablesWithIdsTable}${x.name}""", x.terms)
     }
-
-    val internalVarJoinConds = headAsBody.zipWithIndex flatMap {
-      case (x: Atom, i) if schemaDeclarationByRelationName get x.name exists (_.isQuery) =>
-        List(
-          // project variable key columns as well (to reduce unnecssary joins)
-          schemaDeclarationByRelationName get x.name map (_.keyColumns map {
-            case term => s"""R${headAsBody indexOf x}.${term} = ${deepdiveVariableIdColumn}_${headAsBody indexOf x}.${term}"""
-          }) get
-        )
-      case _ => List.empty
-    } flatten
 
     var nonCategoryWeightCols = new HashSet[String]()
 
@@ -554,11 +542,11 @@ class QueryCompiler(cq : ConjunctiveQuery, hackFrom: List[String] = Nil, hackWhe
         // Here we need to select from the bodies atoms as well as the head atoms,
         // which are the variable relations.
         // This is achieved by puting head atoms into the body.
-        val fakeBody        = headAsBody ++ cqBody
+        val fakeBody        = headAsBodyWithIds ++ cqBody
         val fakeCQ          = stmt.q.copy(bodies = List(fakeBody))
 
         // TODO XXX: Fix the `internal` hack below
-        val qc = new QueryCompiler(fakeCQ, internalVarTables, internalVarJoinConds)
+        val qc = new QueryCompiler(fakeCQ)
 
         // weight columns
         val weightColumns = stmt.weights.variables.zipWithIndex collect {
@@ -685,7 +673,7 @@ object DeepDiveLogCompiler extends DeepDiveLogHandler {
   val deepdiveVariableIdColumn = "dd_id"
   val deepdiveVariableLabelColumn = "dd_label"
   val deepdiveVariableLabelTruthinessColumn = "dd_truthiness"
-  val deepdivePrefixForVariablesIdsTable = "dd_variables_"
+  val deepdivePrefixForVariablesWithIdsTable = "dd_predicate_"
 
   // entry point for compilation
   override def run(parsedProgram: DeepDiveLog.Program, config: DeepDiveLog.Config) = {

--- a/test/expected-output-test/chunking_example/compile.expected
+++ b/test/expected-output-test/chunking_example/compile.expected
@@ -85,27 +85,25 @@ deepdive.inference.factors.inf_istrue_chunk {
 weight: """?(dd_weight_column_0, dd_weight_column_1)"""
 non_category_weight_cols: [
   dd_weight_column_0
+  dd_weight_column_1
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "chunk.R0.dd_id"
+SELECT R0.dd_id AS "chunk.R0.dd_id"
      , R0.sent_id AS "chunk.R0.sent_id"
      , R0.word_id AS "chunk.R0.word_id"
      , R0.tag AS "chunk.R0.tag"
      , R3.feature AS "dd_weight_column_0"
      , R0.tag AS "dd_weight_column_1"
      , (R3.feature)::float AS feature_value
-FROM chunk R0
+FROM dd_predicate_chunk R0
    , words R1
    , tags R2
    , word_features R3
-   , dd_variables_chunk AS dd_id_0
 WHERE R1.sent_id = R0.sent_id
   AND R1.word_id = R0.word_id
   AND R2.tag = R0.tag
   AND R3.sent_id = R0.sent_id
   AND R3.word_id = R0.word_id
-  AND R0.sent_id = dd_id_0.sent_id
-  AND R0.word_id = dd_id_0.word_id
 """
 input_relations: [
   chunk
@@ -120,28 +118,27 @@ function: """AndCategorical(chunk.R0.dd_label)"""
 deepdive.inference.factors.linear_chain {
 weight: """?(dd_weight_column_0, dd_weight_column_1)"""
 non_category_weight_cols: [
-  
+  dd_weight_column_0
+  dd_weight_column_1
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "chunk.R0.dd_id"
+SELECT R0.dd_id AS "chunk.R0.dd_id"
      , R0.sent_id AS "chunk.R0.sent_id"
      , R0.word_id AS "chunk.R0.word_id"
      , R0.tag AS "chunk.R0.tag"
-     , dd_id_1.dd_id AS "chunk.R1.dd_id"
+     , R1.dd_id AS "chunk.R1.dd_id"
      , R1.sent_id AS "chunk.R1.sent_id"
      , R1.word_id AS "chunk.R1.word_id"
      , R1.tag AS "chunk.R1.tag"
      , R0.tag AS "dd_weight_column_0"
      , R1.tag AS "dd_weight_column_1"
      , (1)::float AS feature_value
-FROM chunk R0
-   , chunk R1
+FROM dd_predicate_chunk R0
+   , dd_predicate_chunk R1
    , words R2
    , words R3
    , tags R4
    , tags R5
-   , dd_variables_chunk AS dd_id_0
-   , dd_variables_chunk AS dd_id_1
 WHERE R1.sent_id = R0.sent_id
   AND R2.sent_id = R0.sent_id
   AND R2.word_id = R0.word_id
@@ -150,10 +147,6 @@ WHERE R1.sent_id = R0.sent_id
   AND R4.tag = R0.tag
   AND R5.tag = R1.tag
   AND R1.word_id = (R0.word_id + 1)
-  AND R0.sent_id = dd_id_0.sent_id
-  AND R0.word_id = dd_id_0.word_id
-  AND R1.sent_id = dd_id_1.sent_id
-  AND R1.word_id = dd_id_1.word_id
 """
 input_relations: [
   chunk
@@ -167,28 +160,27 @@ function: """AndCategorical(chunk.R0.dd_label, chunk.R1.dd_label)"""
 deepdive.inference.factors.phony_rule {
 weight: """?(dd_weight_column_0, dd_weight_column_1)"""
 non_category_weight_cols: [
-  
+  dd_weight_column_0
+  dd_weight_column_1
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "chunk.R0.dd_id"
+SELECT R0.dd_id AS "chunk.R0.dd_id"
      , R0.sent_id AS "chunk.R0.sent_id"
      , R0.word_id AS "chunk.R0.word_id"
      , R0.tag AS "chunk.R0.tag"
-     , dd_id_1.dd_id AS "chunk.R1.dd_id"
+     , R1.dd_id AS "chunk.R1.dd_id"
      , R1.sent_id AS "chunk.R1.sent_id"
      , R1.word_id AS "chunk.R1.word_id"
      , R1.tag AS "chunk.R1.tag"
      , R0.tag AS "dd_weight_column_0"
      , R1.tag AS "dd_weight_column_1"
      , (1)::float AS feature_value
-FROM chunk R0
-   , chunk R1
+FROM dd_predicate_chunk R0
+   , dd_predicate_chunk R1
    , words R2
    , words R3
    , tags R4
    , tags R5
-   , dd_variables_chunk AS dd_id_0
-   , dd_variables_chunk AS dd_id_1
 WHERE R1.sent_id = R0.sent_id
   AND R2.sent_id = R0.sent_id
   AND R2.word_id = R0.word_id
@@ -198,10 +190,6 @@ WHERE R1.sent_id = R0.sent_id
   AND R5.tag = R1.tag
   AND R2.tag IS NOT NULL
   AND R0.word_id < R1.word_id
-  AND R0.sent_id = dd_id_0.sent_id
-  AND R0.word_id = dd_id_0.word_id
-  AND R1.sent_id = dd_id_1.sent_id
-  AND R1.word_id = dd_id_1.word_id
 """
 input_relations: [
   chunk

--- a/test/expected-output-test/chunking_example/compile.expected
+++ b/test/expected-output-test/chunking_example/compile.expected
@@ -13,7 +13,7 @@ sql: """
 SELECT R0.sent_id AS column_0
      , R0.word_id AS column_1
      , R1.tag AS column_2
-     , 
+     ,
 CASE WHEN R1.tag = R0.tag THEN true
      ELSE NULL
 END AS column_3
@@ -38,7 +38,7 @@ SELECT R0.sent_id AS column_0
      , R0.word AS column_2
      , R0.pos AS column_3
      , R0.true_tag AS column_4
-     , 
+     ,
 CASE WHEN R0.true_tag = 'B-UCP' THEN NULL
      WHEN R0.true_tag = 'I-UCP' THEN NULL
      WHEN strpos(R0.true_tag, '-') > 0 THEN split_part(R0.true_tag, '-', 2)
@@ -95,7 +95,7 @@ SELECT R0.dd_id AS "chunk.R0.dd_id"
      , R3.feature AS "dd_weight_column_0"
      , R0.tag AS "dd_weight_column_1"
      , (R3.feature)::float AS feature_value
-FROM dd_predicate_chunk R0
+FROM dd_variables_with_id_chunk R0
    , words R1
    , tags R2
    , word_features R3
@@ -133,8 +133,8 @@ SELECT R0.dd_id AS "chunk.R0.dd_id"
      , R0.tag AS "dd_weight_column_0"
      , R1.tag AS "dd_weight_column_1"
      , (1)::float AS feature_value
-FROM dd_predicate_chunk R0
-   , dd_predicate_chunk R1
+FROM dd_variables_with_id_chunk R0
+   , dd_variables_with_id_chunk R1
    , words R2
    , words R3
    , tags R4
@@ -175,8 +175,8 @@ SELECT R0.dd_id AS "chunk.R0.dd_id"
      , R0.tag AS "dd_weight_column_0"
      , R1.tag AS "dd_weight_column_1"
      , (1)::float AS feature_value
-FROM dd_predicate_chunk R0
-   , dd_predicate_chunk R1
+FROM dd_variables_with_id_chunk R0
+   , dd_variables_with_id_chunk R1
    , words R2
    , words R3
    , tags R4

--- a/test/expected-output-test/factor_functions/compile.expected
+++ b/test/expected-output-test/factor_functions/compile.expected
@@ -18,8 +18,8 @@ SELECT R0.dd_id AS "Q.R0.dd_id"
      , R1.x AS "Q.R1.x"
      , R1.x AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM dd_predicate_Q R0
-   , dd_predicate_Q R1
+FROM dd_variables_with_id_Q R0
+   , dd_variables_with_id_Q R1
    , R R2
 WHERE R2.a = R0.x
   AND R2.b = R1.x
@@ -44,8 +44,8 @@ SELECT R0.dd_id AS "Q.R0.dd_id"
      , R1.x AS "Q.R1.x"
      , R1.x AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM dd_predicate_Q R0
-   , dd_predicate_Q R1
+FROM dd_variables_with_id_Q R0
+   , dd_variables_with_id_Q R1
    , R R2
 WHERE R2.a = R0.x
   AND R2.b = R1.x

--- a/test/expected-output-test/factor_functions/compile.expected
+++ b/test/expected-output-test/factor_functions/compile.expected
@@ -12,21 +12,17 @@ non_category_weight_cols: [
   dd_weight_column_0
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "Q.R0.dd_id"
+SELECT R0.dd_id AS "Q.R0.dd_id"
      , R0.x AS "Q.R0.x"
-     , dd_id_1.dd_id AS "Q.R1.dd_id"
+     , R1.dd_id AS "Q.R1.dd_id"
      , R1.x AS "Q.R1.x"
      , R1.x AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM Q R0
-   , Q R1
+FROM dd_predicate_Q R0
+   , dd_predicate_Q R1
    , R R2
-   , dd_variables_Q AS dd_id_0
-   , dd_variables_Q AS dd_id_1
 WHERE R2.a = R0.x
   AND R2.b = R1.x
-  AND R0.x = dd_id_0.x
-  AND R1.x = dd_id_1.x
 """
 input_relations: [
   Q
@@ -42,21 +38,17 @@ non_category_weight_cols: [
   dd_weight_column_0
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "Q.R0.dd_id"
+SELECT R0.dd_id AS "Q.R0.dd_id"
      , R0.x AS "Q.R0.x"
-     , dd_id_1.dd_id AS "Q.R1.dd_id"
+     , R1.dd_id AS "Q.R1.dd_id"
      , R1.x AS "Q.R1.x"
      , R1.x AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM Q R0
-   , Q R1
+FROM dd_predicate_Q R0
+   , dd_predicate_Q R1
    , R R2
-   , dd_variables_Q AS dd_id_0
-   , dd_variables_Q AS dd_id_1
 WHERE R2.a = R0.x
   AND R2.b = R1.x
-  AND R0.x = dd_id_0.x
-  AND R1.x = dd_id_1.x
 """
 input_relations: [
   Q

--- a/test/expected-output-test/logical_rules/compile.expected
+++ b/test/expected-output-test/logical_rules/compile.expected
@@ -39,22 +39,18 @@ materialize: false
 deepdive.inference.factors.inf_imply_P_Q {
 weight: """1"""
 non_category_weight_cols: [
-
+  
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "P.R0.dd_id"
+SELECT R0.dd_id AS "P.R0.dd_id"
      , R0.x AS "P.R0.x"
-     , dd_id_1.dd_id AS "Q.R1.dd_id"
+     , R1.dd_id AS "Q.R1.dd_id"
      , R1.x AS "Q.R1.x"
      , (1)::float AS feature_value
-FROM P R0
-   , Q R1
-   , dd_variables_P AS dd_id_0
-   , dd_variables_Q AS dd_id_1
+FROM dd_predicate_P R0
+   , dd_predicate_Q R1
 WHERE R1.x = R0.x
   AND true
-  AND R0.x = dd_id_0.x
-  AND R1.x = dd_id_1.x
 """
 input_relations: [
   P

--- a/test/expected-output-test/logical_rules/compile.expected
+++ b/test/expected-output-test/logical_rules/compile.expected
@@ -39,7 +39,7 @@ materialize: false
 deepdive.inference.factors.inf_imply_P_Q {
 weight: """1"""
 non_category_weight_cols: [
-  
+
 ]
 input_query: """
 SELECT R0.dd_id AS "P.R0.dd_id"
@@ -47,8 +47,8 @@ SELECT R0.dd_id AS "P.R0.dd_id"
      , R1.dd_id AS "Q.R1.dd_id"
      , R1.x AS "Q.R1.x"
      , (1)::float AS feature_value
-FROM dd_predicate_P R0
-   , dd_predicate_Q R1
+FROM dd_variables_with_id_P R0
+   , dd_variables_with_id_Q R1
 WHERE R1.x = R0.x
   AND true
 """

--- a/test/expected-output-test/multiple_rules_for_same_head/compile.expected
+++ b/test/expected-output-test/multiple_rules_for_same_head/compile.expected
@@ -211,7 +211,7 @@ SELECT R0.dd_id AS "Q.R0.dd_id"
      , R0.x AS "Q.R0.x"
      , R0.x AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM dd_predicate_Q R0
+FROM dd_variables_with_id_Q R0
    , S R1
 WHERE R1.a = R0.x
   AND R0.x > 1000
@@ -227,13 +227,13 @@ function: """Imply(Q.R0.dd_label)"""
 deepdive.inference.factors.inf_istrue_Q_1 {
 weight: """1.0"""
 non_category_weight_cols: [
-  
+
 ]
 input_query: """
 SELECT R0.dd_id AS "Q.R0.dd_id"
      , R0.x AS "Q.R0.x"
      , (1)::float AS feature_value
-FROM dd_predicate_Q R0
+FROM dd_variables_with_id_Q R0
    , S R1
 WHERE R1.a = R0.x
   AND R0.x = 0
@@ -249,13 +249,13 @@ function: """Imply(Q.R0.dd_label)"""
 deepdive.inference.factors.inf_istrue_not_Q {
 weight: """?"""
 non_category_weight_cols: [
-  
+
 ]
 input_query: """
 SELECT R0.dd_id AS "Q.R0.dd_id"
      , R0.x AS "Q.R0.x"
      , (1)::float AS feature_value
-FROM dd_predicate_Q R0
+FROM dd_variables_with_id_Q R0
    , S R1
 WHERE R1.a = R0.x
   AND R0.x < 1000
@@ -280,8 +280,8 @@ SELECT R0.dd_id AS "Q.R0.dd_id"
      , R1.x AS "Q.R1.x"
      , R0.x AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM dd_predicate_Q R0
-   , dd_predicate_Q R1
+FROM dd_variables_with_id_Q R0
+   , dd_variables_with_id_Q R1
    , S R2
    , R R3
    , S R4
@@ -302,7 +302,7 @@ function: """Imply(Q.R0.dd_label, Q.R1.dd_label)"""
 deepdive.inference.factors.inf_imply_Q_Q__1 {
 weight: """-10.0"""
 non_category_weight_cols: [
-  
+
 ]
 input_query: """
 SELECT R0.dd_id AS "Q.R0.dd_id"
@@ -310,8 +310,8 @@ SELECT R0.dd_id AS "Q.R0.dd_id"
      , R1.dd_id AS "Q.R1.dd_id"
      , R1.x AS "Q.R1.x"
      , (1)::float AS feature_value
-FROM dd_predicate_Q R0
-   , dd_predicate_Q R1
+FROM dd_variables_with_id_Q R0
+   , dd_variables_with_id_Q R1
    , S R2
    , R R3
    , S R4
@@ -333,7 +333,7 @@ function: """Imply(Q.R0.dd_label, Q.R1.dd_label)"""
 deepdive.inference.factors.inf_imply_Q_Q__2 {
 weight: """10.0"""
 non_category_weight_cols: [
-  
+
 ]
 input_query: """
 SELECT R0.dd_id AS "Q.R0.dd_id"
@@ -341,8 +341,8 @@ SELECT R0.dd_id AS "Q.R0.dd_id"
      , R1.dd_id AS "Q.R1.dd_id"
      , R1.x AS "Q.R1.x"
      , (1)::float AS feature_value
-FROM dd_predicate_Q R0
-   , dd_predicate_Q R1
+FROM dd_variables_with_id_Q R0
+   , dd_variables_with_id_Q R1
    , S R2
    , R R3
    , S R4
@@ -387,8 +387,8 @@ SELECT R0.dd_id AS "Q.R0.dd_id"
      , R1.x AS "Q1.R1.x"
      , R0.x AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM dd_predicate_Q R0
-   , dd_predicate_Q1 R1
+FROM dd_variables_with_id_Q R0
+   , dd_variables_with_id_Q1 R1
    , S R2
    , R R3
    , S R4
@@ -419,8 +419,8 @@ SELECT R0.dd_id AS "Q.R0.dd_id"
      , R1.x AS "Q_1.R1.x"
      , R0.x AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM dd_predicate_Q R0
-   , dd_predicate_Q_1 R1
+FROM dd_variables_with_id_Q R0
+   , dd_variables_with_id_Q_1 R1
    , S R2
    , R R3
    , S R4

--- a/test/expected-output-test/multiple_rules_for_same_head/compile.expected
+++ b/test/expected-output-test/multiple_rules_for_same_head/compile.expected
@@ -207,16 +207,14 @@ non_category_weight_cols: [
   dd_weight_column_0
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "Q.R0.dd_id"
+SELECT R0.dd_id AS "Q.R0.dd_id"
      , R0.x AS "Q.R0.x"
      , R0.x AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM Q R0
+FROM dd_predicate_Q R0
    , S R1
-   , dd_variables_Q AS dd_id_0
 WHERE R1.a = R0.x
   AND R0.x > 1000
-  AND R0.x = dd_id_0.x
 """
 input_relations: [
   Q
@@ -229,18 +227,16 @@ function: """Imply(Q.R0.dd_label)"""
 deepdive.inference.factors.inf_istrue_Q_1 {
 weight: """1.0"""
 non_category_weight_cols: [
-
+  
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "Q.R0.dd_id"
+SELECT R0.dd_id AS "Q.R0.dd_id"
      , R0.x AS "Q.R0.x"
      , (1)::float AS feature_value
-FROM Q R0
+FROM dd_predicate_Q R0
    , S R1
-   , dd_variables_Q AS dd_id_0
 WHERE R1.a = R0.x
   AND R0.x = 0
-  AND R0.x = dd_id_0.x
 """
 input_relations: [
   Q
@@ -253,18 +249,16 @@ function: """Imply(Q.R0.dd_label)"""
 deepdive.inference.factors.inf_istrue_not_Q {
 weight: """?"""
 non_category_weight_cols: [
-
+  
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "Q.R0.dd_id"
+SELECT R0.dd_id AS "Q.R0.dd_id"
      , R0.x AS "Q.R0.x"
      , (1)::float AS feature_value
-FROM Q R0
+FROM dd_predicate_Q R0
    , S R1
-   , dd_variables_Q AS dd_id_0
 WHERE R1.a = R0.x
   AND R0.x < 1000
-  AND R0.x = dd_id_0.x
 """
 input_relations: [
   Q
@@ -280,25 +274,21 @@ non_category_weight_cols: [
   dd_weight_column_0
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "Q.R0.dd_id"
+SELECT R0.dd_id AS "Q.R0.dd_id"
      , R0.x AS "Q.R0.x"
-     , dd_id_1.dd_id AS "Q.R1.dd_id"
+     , R1.dd_id AS "Q.R1.dd_id"
      , R1.x AS "Q.R1.x"
      , R0.x AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM Q R0
-   , Q R1
+FROM dd_predicate_Q R0
+   , dd_predicate_Q R1
    , S R2
    , R R3
    , S R4
-   , dd_variables_Q AS dd_id_0
-   , dd_variables_Q AS dd_id_1
 WHERE R2.a = R0.x
   AND R3.a = R0.x
   AND R3.b = R1.x
   AND R4.a = R1.x
-  AND R0.x = dd_id_0.x
-  AND R1.x = dd_id_1.x
 """
 input_relations: [
   Q
@@ -312,28 +302,24 @@ function: """Imply(Q.R0.dd_label, Q.R1.dd_label)"""
 deepdive.inference.factors.inf_imply_Q_Q__1 {
 weight: """-10.0"""
 non_category_weight_cols: [
-
+  
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "Q.R0.dd_id"
+SELECT R0.dd_id AS "Q.R0.dd_id"
      , R0.x AS "Q.R0.x"
-     , dd_id_1.dd_id AS "Q.R1.dd_id"
+     , R1.dd_id AS "Q.R1.dd_id"
      , R1.x AS "Q.R1.x"
      , (1)::float AS feature_value
-FROM Q R0
-   , Q R1
+FROM dd_predicate_Q R0
+   , dd_predicate_Q R1
    , S R2
    , R R3
    , S R4
-   , dd_variables_Q AS dd_id_0
-   , dd_variables_Q AS dd_id_1
 WHERE R2.a = R0.x
   AND R3.a = R0.x
   AND R3.b = R1.x
   AND R4.a = R1.x
   AND (R0.x + R1.x) < 1000
-  AND R0.x = dd_id_0.x
-  AND R1.x = dd_id_1.x
 """
 input_relations: [
   Q
@@ -347,28 +333,24 @@ function: """Imply(Q.R0.dd_label, Q.R1.dd_label)"""
 deepdive.inference.factors.inf_imply_Q_Q__2 {
 weight: """10.0"""
 non_category_weight_cols: [
-
+  
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "Q.R0.dd_id"
+SELECT R0.dd_id AS "Q.R0.dd_id"
      , R0.x AS "Q.R0.x"
-     , dd_id_1.dd_id AS "Q.R1.dd_id"
+     , R1.dd_id AS "Q.R1.dd_id"
      , R1.x AS "Q.R1.x"
      , (1)::float AS feature_value
-FROM Q R0
-   , Q R1
+FROM dd_predicate_Q R0
+   , dd_predicate_Q R1
    , S R2
    , R R3
    , S R4
-   , dd_variables_Q AS dd_id_0
-   , dd_variables_Q AS dd_id_1
 WHERE R2.a = R0.x
   AND R3.a = R0.x
   AND R3.b = R1.x
   AND R4.a = R1.x
   AND (R0.x + R1.x) > 1000
-  AND R0.x = dd_id_0.x
-  AND R1.x = dd_id_1.x
 """
 input_relations: [
   Q
@@ -399,25 +381,21 @@ non_category_weight_cols: [
   dd_weight_column_0
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "Q.R0.dd_id"
+SELECT R0.dd_id AS "Q.R0.dd_id"
      , R0.x AS "Q.R0.x"
-     , dd_id_1.dd_id AS "Q1.R1.dd_id"
+     , R1.dd_id AS "Q1.R1.dd_id"
      , R1.x AS "Q1.R1.x"
      , R0.x AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM Q R0
-   , Q1 R1
+FROM dd_predicate_Q R0
+   , dd_predicate_Q1 R1
    , S R2
    , R R3
    , S R4
-   , dd_variables_Q AS dd_id_0
-   , dd_variables_Q1 AS dd_id_1
 WHERE R2.a = R0.x
   AND R3.a = R0.x
   AND R3.b = R1.x
   AND R4.a = R1.x
-  AND R0.x = dd_id_0.x
-  AND R1.x = dd_id_1.x
 """
 input_relations: [
   Q
@@ -435,25 +413,21 @@ non_category_weight_cols: [
   dd_weight_column_0
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "Q.R0.dd_id"
+SELECT R0.dd_id AS "Q.R0.dd_id"
      , R0.x AS "Q.R0.x"
-     , dd_id_1.dd_id AS "Q_1.R1.dd_id"
+     , R1.dd_id AS "Q_1.R1.dd_id"
      , R1.x AS "Q_1.R1.x"
      , R0.x AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM Q R0
-   , Q_1 R1
+FROM dd_predicate_Q R0
+   , dd_predicate_Q_1 R1
    , S R2
    , R R3
    , S R4
-   , dd_variables_Q AS dd_id_0
-   , dd_variables_Q_1 AS dd_id_1
 WHERE R2.a = R0.x
   AND R3.a = R0.x
   AND R3.b = R1.x
   AND R4.a = R1.x
-  AND R0.x = dd_id_0.x
-  AND R1.x = dd_id_1.x
 """
 input_relations: [
   Q

--- a/test/expected-output-test/ocr_example/compile.expected
+++ b/test/expected-output-test/ocr_example/compile.expected
@@ -48,7 +48,7 @@ SELECT R0.dd_id AS "q1.R0.dd_id"
      , R0.wid AS "q1.R0.wid"
      , R1.feature_id AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM dd_predicate_q1 R0
+FROM dd_variables_with_id_q1 R0
    , features R1
 WHERE R1.word_id = R0.wid
 """
@@ -70,7 +70,7 @@ SELECT R0.dd_id AS "q2.R0.dd_id"
      , R0.wid AS "q2.R0.wid"
      , R1.feature_id AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM dd_predicate_q2 R0
+FROM dd_variables_with_id_q2 R0
    , features R1
 WHERE R1.word_id = R0.wid
 """

--- a/test/expected-output-test/ocr_example/compile.expected
+++ b/test/expected-output-test/ocr_example/compile.expected
@@ -44,15 +44,13 @@ non_category_weight_cols: [
   dd_weight_column_0
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "q1.R0.dd_id"
+SELECT R0.dd_id AS "q1.R0.dd_id"
      , R0.wid AS "q1.R0.wid"
      , R1.feature_id AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM q1 R0
+FROM dd_predicate_q1 R0
    , features R1
-   , dd_variables_q1 AS dd_id_0
 WHERE R1.word_id = R0.wid
-  AND R0.wid = dd_id_0.wid
 """
 input_relations: [
   q1
@@ -68,15 +66,13 @@ non_category_weight_cols: [
   dd_weight_column_0
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "q2.R0.dd_id"
+SELECT R0.dd_id AS "q2.R0.dd_id"
      , R0.wid AS "q2.R0.wid"
      , R1.feature_id AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM q2 R0
+FROM dd_predicate_q2 R0
    , features R1
-   , dd_variables_q2 AS dd_id_0
 WHERE R1.word_id = R0.wid
-  AND R0.wid = dd_id_0.wid
 """
 input_relations: [
   q2

--- a/test/expected-output-test/smoke_example/compile.expected
+++ b/test/expected-output-test/smoke_example/compile.expected
@@ -44,20 +44,16 @@ non_category_weight_cols: [
   
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "smoke.R0.dd_id"
+SELECT R0.dd_id AS "smoke.R0.dd_id"
      , R0.person_id AS "smoke.R0.person_id"
-     , dd_id_1.dd_id AS "cancer.R1.dd_id"
+     , R1.dd_id AS "cancer.R1.dd_id"
      , R1.person_id AS "cancer.R1.person_id"
      , (1)::float AS feature_value
-FROM smoke R0
-   , cancer R1
+FROM dd_predicate_smoke R0
+   , dd_predicate_cancer R1
    , person_smokes R2
-   , dd_variables_smoke AS dd_id_0
-   , dd_variables_cancer AS dd_id_1
 WHERE R1.person_id = R0.person_id
   AND R2.person_id = R0.person_id
-  AND R0.person_id = dd_id_0.person_id
-  AND R1.person_id = dd_id_1.person_id
 """
 input_relations: [
   smoke
@@ -74,20 +70,16 @@ non_category_weight_cols: [
   
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "smoke.R0.dd_id"
+SELECT R0.dd_id AS "smoke.R0.dd_id"
      , R0.person_id AS "smoke.R0.person_id"
-     , dd_id_1.dd_id AS "smoke.R1.dd_id"
+     , R1.dd_id AS "smoke.R1.dd_id"
      , R1.person_id AS "smoke.R1.person_id"
      , (1)::float AS feature_value
-FROM smoke R0
-   , smoke R1
+FROM dd_predicate_smoke R0
+   , dd_predicate_smoke R1
    , friends R2
-   , dd_variables_smoke AS dd_id_0
-   , dd_variables_smoke AS dd_id_1
 WHERE R2.person_id = R0.person_id
   AND R2.friend_id = R1.person_id
-  AND R0.person_id = dd_id_0.person_id
-  AND R1.person_id = dd_id_1.person_id
 """
 input_relations: [
   smoke

--- a/test/expected-output-test/smoke_example/compile.expected
+++ b/test/expected-output-test/smoke_example/compile.expected
@@ -41,7 +41,7 @@ materialize: false
 deepdive.inference.factors.inf_imply_smoke_cancer {
 weight: """0.5"""
 non_category_weight_cols: [
-  
+
 ]
 input_query: """
 SELECT R0.dd_id AS "smoke.R0.dd_id"
@@ -49,8 +49,8 @@ SELECT R0.dd_id AS "smoke.R0.dd_id"
      , R1.dd_id AS "cancer.R1.dd_id"
      , R1.person_id AS "cancer.R1.person_id"
      , (1)::float AS feature_value
-FROM dd_predicate_smoke R0
-   , dd_predicate_cancer R1
+FROM dd_variables_with_id_smoke R0
+   , dd_variables_with_id_cancer R1
    , person_smokes R2
 WHERE R1.person_id = R0.person_id
   AND R2.person_id = R0.person_id
@@ -67,7 +67,7 @@ function: """Imply(smoke.R0.dd_label, cancer.R1.dd_label)"""
 deepdive.inference.factors.inf_imply_smoke_smoke {
 weight: """0.4"""
 non_category_weight_cols: [
-  
+
 ]
 input_query: """
 SELECT R0.dd_id AS "smoke.R0.dd_id"
@@ -75,8 +75,8 @@ SELECT R0.dd_id AS "smoke.R0.dd_id"
      , R1.dd_id AS "smoke.R1.dd_id"
      , R1.person_id AS "smoke.R1.person_id"
      , (1)::float AS feature_value
-FROM dd_predicate_smoke R0
-   , dd_predicate_smoke R1
+FROM dd_variables_with_id_smoke R0
+   , dd_variables_with_id_smoke R1
    , friends R2
 WHERE R2.person_id = R0.person_id
   AND R2.friend_id = R1.person_id

--- a/test/expected-output-test/spouse_example/compile.expected
+++ b/test/expected-output-test/spouse_example/compile.expected
@@ -98,17 +98,15 @@ non_category_weight_cols: [
   dd_weight_column_0
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "has_spouse.R0.dd_id"
+SELECT R0.dd_id AS "has_spouse.R0.dd_id"
      , R0.relation_id AS "has_spouse.R0.relation_id"
      , R2.feature AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM has_spouse R0
+FROM dd_predicate_has_spouse R0
    , has_spouse_candidates R1
    , has_spouse_features R2
-   , dd_variables_has_spouse AS dd_id_0
 WHERE R1.relation_id = R0.relation_id
   AND R2.relation_id = R0.relation_id
-  AND R0.relation_id = dd_id_0.relation_id
 """
 input_relations: [
   has_spouse

--- a/test/expected-output-test/spouse_example/compile.expected
+++ b/test/expected-output-test/spouse_example/compile.expected
@@ -102,7 +102,7 @@ SELECT R0.dd_id AS "has_spouse.R0.dd_id"
      , R0.relation_id AS "has_spouse.R0.relation_id"
      , R2.feature AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM dd_predicate_has_spouse R0
+FROM dd_variables_with_id_has_spouse R0
    , has_spouse_candidates R1
    , has_spouse_features R2
 WHERE R1.relation_id = R0.relation_id

--- a/test/expected-output-test/weights/compile.expected
+++ b/test/expected-output-test/weights/compile.expected
@@ -19,7 +19,7 @@ SELECT R0.dd_id AS "a.R0.dd_id"
      , R0.k AS "a.R0.k"
      , R0.k + R1.p AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM dd_predicate_a R0
+FROM dd_variables_with_id_a R0
    , b R1
 WHERE R1.k = R0.k
 """
@@ -34,13 +34,13 @@ function: """Imply(a.R0.dd_label)"""
 deepdive.inference.factors.inf_istrue_c {
 weight: """?"""
 non_category_weight_cols: [
-  
+
 ]
 input_query: """
 SELECT R0.dd_id AS "c.R0.dd_id"
      , R0.k AS "c.R0.k"
      , (1)::float AS feature_value
-FROM dd_predicate_c R0
+FROM dd_variables_with_id_c R0
    , b R1
 WHERE R1.k = R0.k
 """
@@ -64,7 +64,7 @@ SELECT R0.dd_id AS "d.R0.dd_id"
      , R0.k AS "dd_weight_column_0"
      , R1.p AS "dd_weight_column_1"
      , (1)::float AS feature_value
-FROM dd_predicate_d R0
+FROM dd_variables_with_id_d R0
    , b R1
 WHERE R1.k = R0.k
 """
@@ -79,13 +79,13 @@ function: """Imply(d.R0.dd_label)"""
 deepdive.inference.factors.inf_istrue_e {
 weight: """-10"""
 non_category_weight_cols: [
-  
+
 ]
 input_query: """
 SELECT R0.dd_id AS "e.R0.dd_id"
      , R0.k AS "e.R0.k"
      , (1)::float AS feature_value
-FROM dd_predicate_e R0
+FROM dd_variables_with_id_e R0
    , b R1
 WHERE R1.k = R0.k
 """
@@ -100,13 +100,13 @@ function: """Imply(e.R0.dd_label)"""
 deepdive.inference.factors.inf_istrue_f {
 weight: """-0.3"""
 non_category_weight_cols: [
-  
+
 ]
 input_query: """
 SELECT R0.dd_id AS "f.R0.dd_id"
      , R0.k AS "f.R0.k"
      , (1)::float AS feature_value
-FROM dd_predicate_f R0
+FROM dd_variables_with_id_f R0
    , b R1
 WHERE R1.k = R0.k
 """

--- a/test/expected-output-test/weights/compile.expected
+++ b/test/expected-output-test/weights/compile.expected
@@ -15,15 +15,13 @@ non_category_weight_cols: [
   dd_weight_column_0
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "a.R0.dd_id"
+SELECT R0.dd_id AS "a.R0.dd_id"
      , R0.k AS "a.R0.k"
      , R0.k + R1.p AS "dd_weight_column_0"
      , (1)::float AS feature_value
-FROM a R0
+FROM dd_predicate_a R0
    , b R1
-   , dd_variables_a AS dd_id_0
 WHERE R1.k = R0.k
-  AND R0.k = dd_id_0.k
 """
 input_relations: [
   a
@@ -36,17 +34,15 @@ function: """Imply(a.R0.dd_label)"""
 deepdive.inference.factors.inf_istrue_c {
 weight: """?"""
 non_category_weight_cols: [
-
+  
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "c.R0.dd_id"
+SELECT R0.dd_id AS "c.R0.dd_id"
      , R0.k AS "c.R0.k"
      , (1)::float AS feature_value
-FROM c R0
+FROM dd_predicate_c R0
    , b R1
-   , dd_variables_c AS dd_id_0
 WHERE R1.k = R0.k
-  AND R0.k = dd_id_0.k
 """
 input_relations: [
   c
@@ -63,16 +59,14 @@ non_category_weight_cols: [
   dd_weight_column_1
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "d.R0.dd_id"
+SELECT R0.dd_id AS "d.R0.dd_id"
      , R0.k AS "d.R0.k"
      , R0.k AS "dd_weight_column_0"
      , R1.p AS "dd_weight_column_1"
      , (1)::float AS feature_value
-FROM d R0
+FROM dd_predicate_d R0
    , b R1
-   , dd_variables_d AS dd_id_0
 WHERE R1.k = R0.k
-  AND R0.k = dd_id_0.k
 """
 input_relations: [
   d
@@ -85,17 +79,15 @@ function: """Imply(d.R0.dd_label)"""
 deepdive.inference.factors.inf_istrue_e {
 weight: """-10"""
 non_category_weight_cols: [
-
+  
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "e.R0.dd_id"
+SELECT R0.dd_id AS "e.R0.dd_id"
      , R0.k AS "e.R0.k"
      , (1)::float AS feature_value
-FROM e R0
+FROM dd_predicate_e R0
    , b R1
-   , dd_variables_e AS dd_id_0
 WHERE R1.k = R0.k
-  AND R0.k = dd_id_0.k
 """
 input_relations: [
   e
@@ -108,17 +100,15 @@ function: """Imply(e.R0.dd_label)"""
 deepdive.inference.factors.inf_istrue_f {
 weight: """-0.3"""
 non_category_weight_cols: [
-
+  
 ]
 input_query: """
-SELECT dd_id_0.dd_id AS "f.R0.dd_id"
+SELECT R0.dd_id AS "f.R0.dd_id"
      , R0.k AS "f.R0.k"
      , (1)::float AS feature_value
-FROM f R0
+FROM dd_predicate_f R0
    , b R1
-   , dd_variables_f AS dd_id_0
 WHERE R1.k = R0.k
-  AND R0.k = dd_id_0.k
 """
 input_relations: [
   f


### PR DESCRIPTION
`dd_predicate_V` extends variable table `V` with two additional columns (copied from the var ID table): `dd_id` (var ID) and `dd_part` (partition ID).